### PR TITLE
feat(ui): remove source of patient selection from Patient Intake Step 2

### DIFF
--- a/web-app/src/pages/PatientIntakeStep2.tsx
+++ b/web-app/src/pages/PatientIntakeStep2.tsx
@@ -133,15 +133,6 @@ export function PatientIntakeStep2() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Source of Patient *</label>
-            <select value={sourceOfPatient} onChange={e => setSourceOfPatient(e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm outline-none focus:border-primary bg-white">
-              <option value="">Select</option>
-              {sourceChoices.map(v => <option key={v} value={v}>{v}</option>)}
-            </select>
-          </div>
-
-          <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Case Type *</label>
             <select value={type} onChange={e => setType(e.target.value)}
               className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm outline-none focus:border-primary bg-white">


### PR DESCRIPTION
## What does this PR do?
This pull request makes a small change to the `PatientIntakeStep2` component by removing the "Source of Patient" dropdown field from the form. This simplifies the patient intake process by reducing the number of required fields.

* Removed the "Source of Patient" dropdown, including its label and options, from the `PatientIntakeStep2` form.

## Related Issue
Closes #37 

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Technical / Infrastructure

## How was this tested?
- [ ] Local dev
- [ ] Manual testing
- [ ] Automated tests (if applicable)

## Screenshots / Notes
<img width="831" height="695" alt="image" src="https://github.com/user-attachments/assets/55d0c66c-f2f5-4c91-8448-56b721b2e09d" />