### PR TITLE
feat: backend persistence + demo seeding + risk persistence fixes (closes #54, closes #55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ docs/superpowers/
 workflow.md
 start.sh
 .env
+
+# Backend data (SQLite + X-ray blobs)
+data/

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,44 @@
+# Backend
+
+## Demo Seed Data (Dev Only)
+
+This repo supports seeding a deterministic demo dataset into the backend SQLite DB.
+
+### Storage Locations
+
+- `TB_DATA_DIR`: data root (default: `<repo>/data`)
+- `TB_DB_PATH`: SQLite DB path (default: `$TB_DATA_DIR/tb_cdss.sqlite3`)
+- X-rays are stored under `$TB_DATA_DIR/xrays/`
+
+### Seed Command
+
+Seed demo patients (refuses if DB already has patients):
+
+```bash
+python -m backend.seed_demo
+```
+
+Seed demo patients plus a couple of tiny demo X-ray files:
+
+```bash
+python -m backend.seed_demo --include-xrays
+```
+
+### Reset + Seed (Destructive)
+
+Reset is intentionally guarded. You must opt in via:
+
+- `TB_ALLOW_DEV_RESET=1`
+
+Then run:
+
+```bash
+TB_ALLOW_DEV_RESET=1 python -m backend.seed_demo --reset --include-xrays
+```
+
+You can also reset only one part:
+
+```bash
+TB_ALLOW_DEV_RESET=1 python -m backend.seed_demo --reset-db
+TB_ALLOW_DEV_RESET=1 python -m backend.seed_demo --reset-xrays
+```

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = backend/alembic
+
+# This is overridden at runtime by env.py for normal app usage.
+sqlalchemy.url = sqlite+pysqlite:///./tb_cdss.sqlite3
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/README
+++ b/backend/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from backend import settings
+from backend.db import Base
+from backend import models  # noqa: F401  (ensure models registered)
+
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def get_url() -> str:
+    return settings.sqlalchemy_database_url()
+
+
+def run_migrations_offline() -> None:
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section) or {}
+    configuration["sqlalchemy.url"] = get_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,25 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/20260511_0001_v1_schema.py
+++ b/backend/alembic/versions/20260511_0001_v1_schema.py
@@ -1,0 +1,89 @@
+"""v1 schema
+
+Revision ID: 20260511_0001
+Revises: 
+Create Date: 2026-05-11
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260511_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "patients",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("medical_id", sa.String(), nullable=False),
+        sa.Column("features", sa.JSON(), nullable=False),
+        sa.Column("treatment_regimen", sa.String(), nullable=True),
+        sa.Column("treatment_start_date", sa.String(), nullable=True),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+    )
+
+    op.create_table(
+        "predictions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("patient_id", sa.String(), sa.ForeignKey("patients.id"), nullable=False),
+        sa.Column("label", sa.Integer(), nullable=False),
+        sa.Column("failure_probability", sa.Float(), nullable=False),
+        sa.Column("contributions", sa.JSON(), nullable=False),
+        sa.Column("features_used", sa.JSON(), nullable=True),
+        sa.Column("timestamp", sa.Integer(), nullable=False),
+    )
+    op.create_index("ix_predictions_patient_id", "predictions", ["patient_id"])
+
+    op.create_table(
+        "monthly_records",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("patient_id", sa.String(), sa.ForeignKey("patients.id"), nullable=False),
+        sa.Column("month", sa.Integer(), nullable=False),
+        sa.Column("weight", sa.Float(), nullable=True),
+        sa.Column("smear_result", sa.String(), nullable=True),
+        sa.Column("adherence", sa.String(), nullable=False),
+        sa.Column("failure_probability", sa.Float(), nullable=False),
+        sa.Column("timestamp", sa.Integer(), nullable=False),
+    )
+    op.create_index("ix_monthly_records_patient_id", "monthly_records", ["patient_id"])
+    op.create_index(
+        "ux_monthly_records_patient_month",
+        "monthly_records",
+        ["patient_id", "month"],
+        unique=True,
+    )
+
+    op.create_table(
+        "xrays",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("patient_id", sa.String(), sa.ForeignKey("patients.id"), nullable=False),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("month", sa.Integer(), nullable=True),
+        sa.Column("mime", sa.String(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("sha256", sa.String(), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("rel_path", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Integer(), nullable=False),
+    )
+    op.create_index("ix_xrays_patient_id", "xrays", ["patient_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_xrays_patient_id", table_name="xrays")
+    op.drop_table("xrays")
+
+    op.drop_index("ux_monthly_records_patient_month", table_name="monthly_records")
+    op.drop_index("ix_monthly_records_patient_id", table_name="monthly_records")
+    op.drop_table("monthly_records")
+
+    op.drop_index("ix_predictions_patient_id", table_name="predictions")
+    op.drop_table("predictions")
+
+    op.drop_table("patients")

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+from backend import settings
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+def _ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+_engine: Engine | None = None
+_engine_url: str | None = None
+
+
+def engine() -> Engine:
+    global _engine, _engine_url
+    url = settings.sqlalchemy_database_url()
+    if _engine is not None and _engine_url == url:
+        return _engine
+
+    dbp = settings.db_path()
+    _ensure_parent_dir(dbp)
+    _engine = create_engine(
+        url,
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    _engine_url = url
+    return _engine
+
+
+def session_factory():
+    return sessionmaker(bind=engine(), autoflush=False, autocommit=False, future=True)
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = session_factory()()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _reset_engine_for_tests() -> None:
+    global _engine, _engine_url
+    _engine = None
+    _engine_url = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,18 +1,22 @@
 import asyncio
 import json
 import logging
+import os
 import threading
 import time
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncGenerator, Literal
+from typing import Annotated, AsyncGenerator, Literal
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
-from config import (
+from backend.config import (
     MAX_TOKENS,
     MODEL_PATH,
     N_CTX,
@@ -22,7 +26,22 @@ from config import (
     TEMPERATURE,
     TOP_P,
 )
-from prompt import build_prompt
+from backend.db import get_db
+from backend.models import MonthlyRecord as MonthlyRecordRow
+from backend.models import Patient as PatientRow
+from backend.models import Prediction as PredictionRow
+from backend.models import Xray as XrayRow
+from backend.prompt import build_prompt
+from backend.schemas import (
+    MonthlyRecordCreate,
+    Patient,
+    PatientCreate,
+    PredictionCreate,
+    XrayMetadata,
+    XrayUploadResponse,
+)
+from backend.settings import data_dir, max_upload_bytes
+from backend.xray_store import XrayFileStore, new_xray_id
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -113,6 +132,70 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _patient_to_api(db: Session, p: PatientRow) -> dict:
+    xrays = db.scalars(select(XrayRow).where(XrayRow.patient_id == p.id)).all()
+    intake_ids = [x.id for x in xrays if x.kind == "intake"]
+
+    records = db.scalars(
+        select(MonthlyRecordRow)
+        .where(MonthlyRecordRow.patient_id == p.id)
+        .order_by(MonthlyRecordRow.month.asc())
+    ).all()
+    record_id_to_xray_ids: dict[int, list[str]] = {}
+    for x in xrays:
+        if x.kind == "monthly" and x.month is not None:
+            # Client buckets by month number.
+            record_id_to_xray_ids.setdefault(x.month, []).append(x.id)
+
+    predictions = db.scalars(
+        select(PredictionRow)
+        .where(PredictionRow.patient_id == p.id)
+        .order_by(PredictionRow.timestamp.asc())
+    ).all()
+
+    return Patient(
+        id=p.id,
+        name=p.name,
+        medicalId=p.medical_id,
+        features=p.features,
+        treatmentRegimen=p.treatment_regimen,
+        treatmentStartDate=p.treatment_start_date,
+        createdAt=p.created_at,
+        predictions=[
+            {
+                "label": int(r.label),
+                "failureProbability": float(r.failure_probability),
+                "contributions": r.contributions,
+                "featuresUsed": r.features_used,
+                "timestamp": int(r.timestamp),
+            }
+            for r in predictions
+        ],
+        monthlyRecords=[
+            {
+                "month": int(r.month),
+                "weight": float(r.weight) if r.weight is not None else None,
+                "smearResult": r.smear_result,
+                "adherence": r.adherence,
+                "failureProbability": float(r.failure_probability),
+                "timestamp": int(r.timestamp),
+                "xrayIds": record_id_to_xray_ids.get(int(r.month)) or None,
+            }
+            for r in records
+        ],
+        intakeXrayIds=intake_ids or None,
+    ).model_dump(by_alias=True)
+
+
+def _xray_store() -> XrayFileStore:
+    return XrayFileStore(data_dir() / "xrays")
 
 
 # ---------------------------------------------------------------------------
@@ -288,3 +371,199 @@ async def interpret(req: InterpretRequest, request: Request):
     prompt = build_prompt(req)
     log.debug("Prompt built (%d chars)", len(prompt))
     return EventSourceResponse(_generate(prompt, lock, req.patient_name, request))
+
+
+@app.get("/api/patients")
+def list_patients(db: Annotated[Session, Depends(get_db)]):
+    patients = db.scalars(select(PatientRow).order_by(PatientRow.created_at.desc())).all()
+    return [_patient_to_api(db, p) for p in patients]
+
+
+@app.post("/api/patients")
+def create_patient(body: PatientCreate, db: Annotated[Session, Depends(get_db)]):
+    pid = body.id or f"MED-{time.gmtime().tm_year}-{int.from_bytes(os.urandom(2), 'big'):04d}"
+    created_at = body.created_at or int(time.time() * 1000)
+
+    existing = db.get(PatientRow, pid)
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="Patient id already exists")
+
+    row = PatientRow(
+        id=pid,
+        name=body.name,
+        medical_id=body.medical_id,
+        features=body.features.model_dump(by_alias=True),
+        treatment_regimen=body.treatment_regimen,
+        treatment_start_date=body.treatment_start_date,
+        created_at=created_at,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _patient_to_api(db, row)
+
+
+@app.put("/api/patients/{patient_id}")
+def upsert_patient(
+    patient_id: str, body: PatientCreate, db: Annotated[Session, Depends(get_db)]
+):
+    # Used by the web app to persist edits (regimen, start date, etc.).
+    created_at = body.created_at or int(time.time() * 1000)
+
+    row = db.get(PatientRow, patient_id)
+    if row is None:
+        row = PatientRow(
+            id=patient_id,
+            name=body.name,
+            medical_id=body.medical_id,
+            features=body.features.model_dump(by_alias=True),
+            treatment_regimen=body.treatment_regimen,
+            treatment_start_date=body.treatment_start_date,
+            created_at=created_at,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return _patient_to_api(db, row)
+
+    row.name = body.name
+    row.medical_id = body.medical_id
+    row.features = body.features.model_dump(by_alias=True)
+    row.treatment_regimen = body.treatment_regimen
+    row.treatment_start_date = body.treatment_start_date
+    # Preserve original created_at if already set.
+    row.created_at = row.created_at or created_at
+    db.commit()
+    return _patient_to_api(db, row)
+
+
+@app.get("/api/patients/{patient_id}")
+def get_patient(patient_id: str, db: Annotated[Session, Depends(get_db)]):
+    p = db.get(PatientRow, patient_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Patient not found")
+    return _patient_to_api(db, p)
+
+
+@app.post("/api/patients/{patient_id}/monthly-records")
+def add_monthly_record(
+    patient_id: str, body: MonthlyRecordCreate, db: Annotated[Session, Depends(get_db)]
+):
+    p = db.get(PatientRow, patient_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Patient not found")
+
+    row = MonthlyRecordRow(
+        patient_id=patient_id,
+        month=body.month,
+        weight=body.weight,
+        smear_result=body.smear_result,
+        adherence=body.adherence,
+        failure_probability=body.failure_probability,
+        timestamp=body.timestamp,
+    )
+    db.add(row)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Monthly record already exists")
+    return {"ok": True}
+
+
+@app.post("/api/patients/{patient_id}/predictions")
+def add_prediction(
+    patient_id: str, body: PredictionCreate, db: Annotated[Session, Depends(get_db)]
+):
+    p = db.get(PatientRow, patient_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Patient not found")
+
+    row = PredictionRow(
+        patient_id=patient_id,
+        label=int(body.label),
+        failure_probability=float(body.failure_probability),
+        contributions=[c.model_dump() for c in body.contributions],
+        features_used=body.features_used,
+        timestamp=int(body.timestamp),
+    )
+    db.add(row)
+    db.commit()
+    return {"ok": True}
+
+
+@app.post("/api/xrays")
+async def upload_xray(
+    db: Annotated[Session, Depends(get_db)],
+    file: UploadFile,
+    patient_id: str,
+    kind: Literal["intake", "monthly"],
+    month: int | None = None,
+):
+    p = db.get(PatientRow, patient_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Patient not found")
+    if kind == "monthly" and month is None:
+        raise HTTPException(status_code=400, detail="month is required for monthly xrays")
+
+    xray_id = new_xray_id()
+    store = _xray_store()
+    rel_path, sha256, size_bytes, mime = await store.save(
+        xray_id=xray_id, file=file, max_bytes=max_upload_bytes()
+    )
+
+    row = XrayRow(
+        id=xray_id,
+        patient_id=patient_id,
+        kind=kind,
+        month=month,
+        mime=mime,
+        name=file.filename or xray_id,
+        sha256=sha256,
+        size_bytes=size_bytes,
+        rel_path=rel_path,
+        created_at=int(time.time() * 1000),
+    )
+    db.add(row)
+    db.commit()
+    return XrayUploadResponse(id=xray_id, sha256=sha256, sizeBytes=size_bytes, mime=mime).model_dump(
+        by_alias=True
+    )
+
+
+@app.get("/api/xrays/{xray_id}/file")
+def get_xray_file(xray_id: str, db: Annotated[Session, Depends(get_db)]):
+    x = db.get(XrayRow, xray_id)
+    if x is None:
+        raise HTTPException(status_code=404, detail="X-ray not found")
+
+    root = (data_dir() / "xrays").resolve()
+    file_path = (root / x.rel_path).resolve()
+    if root not in file_path.parents:
+        raise HTTPException(status_code=500, detail="Invalid stored path")
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="X-ray file missing")
+    return FileResponse(path=str(file_path), media_type=x.mime, filename=x.name)
+
+
+@app.get("/api/patients/{patient_id}/xrays")
+def list_patient_xrays(patient_id: str, db: Annotated[Session, Depends(get_db)]):
+    p = db.get(PatientRow, patient_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Patient not found")
+
+    xrays = db.scalars(select(XrayRow).where(XrayRow.patient_id == patient_id)).all()
+    return [
+        XrayMetadata(
+            id=x.id,
+            patientId=x.patient_id,
+            kind=x.kind,
+            month=x.month,
+            mime=x.mime,
+            name=x.name,
+            sha256=x.sha256,
+            sizeBytes=x.size_bytes,
+            createdAt=x.created_at,
+        ).model_dump(by_alias=True)
+        for x in xrays
+    ]

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from sqlalchemy import Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import JSON
+
+from backend.db import Base
+
+
+class Patient(Base):
+    __tablename__ = "patients"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    medical_id: Mapped[str] = mapped_column(String, nullable=False)
+    features: Mapped[dict] = mapped_column(JSON, nullable=False)
+    treatment_regimen: Mapped[str | None] = mapped_column(String, nullable=True)
+    treatment_start_date: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    predictions: Mapped[list[Prediction]] = relationship(
+        back_populates="patient", cascade="all, delete-orphan"
+    )
+    monthly_records: Mapped[list[MonthlyRecord]] = relationship(
+        back_populates="patient", cascade="all, delete-orphan"
+    )
+    xrays: Mapped[list[Xray]] = relationship(
+        back_populates="patient", cascade="all, delete-orphan"
+    )
+
+
+class Prediction(Base):
+    __tablename__ = "predictions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    patient_id: Mapped[str] = mapped_column(ForeignKey("patients.id"), nullable=False)
+
+    label: Mapped[int] = mapped_column(Integer, nullable=False)
+    failure_probability: Mapped[float] = mapped_column(Float, nullable=False)
+    contributions: Mapped[list[dict]] = mapped_column(JSON, nullable=False)
+    features_used: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    timestamp: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    patient: Mapped[Patient] = relationship(back_populates="predictions")
+
+
+class MonthlyRecord(Base):
+    __tablename__ = "monthly_records"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    patient_id: Mapped[str] = mapped_column(ForeignKey("patients.id"), nullable=False)
+
+    month: Mapped[int] = mapped_column(Integer, nullable=False)
+    weight: Mapped[float | None] = mapped_column(Float, nullable=True)
+    smear_result: Mapped[str | None] = mapped_column(String, nullable=True)
+    adherence: Mapped[str] = mapped_column(String, nullable=False)
+    failure_probability: Mapped[float] = mapped_column(Float, nullable=False)
+    timestamp: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    patient: Mapped[Patient] = relationship(back_populates="monthly_records")
+
+
+class Xray(Base):
+    __tablename__ = "xrays"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    patient_id: Mapped[str] = mapped_column(ForeignKey("patients.id"), nullable=False)
+
+    kind: Mapped[str] = mapped_column(String, nullable=False)  # intake | monthly
+    month: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    mime: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    sha256: Mapped[str] = mapped_column(String, nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    rel_path: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    patient: Mapped[Patient] = relationship(back_populates="xrays")

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths =
+    tests
+    backend/tests
+addopts = -q

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,7 @@ uvicorn[standard]>=0.24.0
 llama-cpp-python>=0.3.0
 sse-starlette>=1.6.0
 pydantic>=2.0.0
+SQLAlchemy>=2.0.0
+alembic>=1.12.0
+python-multipart>=0.0.9
+pytest>=8.0.0

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CamelModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class ContributionItem(CamelModel):
+    feature: str
+    delta: float
+    direction: Literal["risk", "protective"]
+
+
+class PredictionRecord(CamelModel):
+    label: Literal[0, 1]
+    failure_probability: float = Field(alias="failureProbability")
+    contributions: list[ContributionItem]
+    features_used: dict[str, Any] | None = Field(default=None, alias="featuresUsed")
+    timestamp: int
+
+
+class MonthlyRecord(CamelModel):
+    month: int
+    weight: float | None = None
+    smear_result: str | None = Field(default=None, alias="smearResult")
+    adherence: Literal["full", "partial", "poor"]
+    failure_probability: float = Field(alias="failureProbability")
+    timestamp: int
+    xray_ids: list[str] | None = Field(default=None, alias="xrayIds")
+
+
+class PatientFeatures(CamelModel):
+    age: int
+    days_to_treatment: int = Field(alias="daysToTreatment")
+    year: int
+    sex: str
+    anatomical_site: str = Field(alias="anatomicalSite")
+    registration_group: str = Field(alias="registrationGroup")
+    bacteriologic_status: str = Field(alias="bacteriologicStatus")
+    microscopy_result: str = Field(alias="microscopyResult")
+    source_of_patient: str = Field(alias="sourceOfPatient")
+    type: str
+    province: str
+    city_municipality: str = Field(alias="cityMunicipality")
+    treatment_health_facility: str = Field(alias="treatmentHealthFacility")
+    screening_diagnosing_health_facility: str = Field(alias="screeningDiagnosingHealthFacility")
+
+
+class PatientCreate(CamelModel):
+    id: str | None = None
+    name: str
+    medical_id: str = Field(alias="medicalId")
+    features: PatientFeatures
+    treatment_regimen: Literal["hrze", "mdr", "xdr"] | None = Field(
+        default=None, alias="treatmentRegimen"
+    )
+    treatment_start_date: str | None = Field(default=None, alias="treatmentStartDate")
+    created_at: int | None = Field(default=None, alias="createdAt")
+
+
+class Patient(CamelModel):
+    id: str
+    name: str
+    medical_id: str = Field(alias="medicalId")
+    features: PatientFeatures
+    treatment_regimen: Literal["hrze", "mdr", "xdr"] | None = Field(
+        default=None, alias="treatmentRegimen"
+    )
+    treatment_start_date: str | None = Field(default=None, alias="treatmentStartDate")
+    created_at: int = Field(alias="createdAt")
+    predictions: list[PredictionRecord]
+    monthly_records: list[MonthlyRecord] = Field(alias="monthlyRecords")
+    intake_xray_ids: list[str] | None = Field(default=None, alias="intakeXrayIds")
+
+
+class MonthlyRecordCreate(CamelModel):
+    month: int
+    weight: float | None = None
+    smear_result: str | None = Field(default=None, alias="smearResult")
+    adherence: Literal["full", "partial", "poor"]
+    failure_probability: float = Field(alias="failureProbability")
+    timestamp: int
+
+
+class PredictionCreate(CamelModel):
+    label: Literal[0, 1]
+    failure_probability: float = Field(alias="failureProbability")
+    contributions: list[ContributionItem]
+    features_used: dict[str, Any] | None = Field(default=None, alias="featuresUsed")
+    timestamp: int
+
+
+class XrayUploadResponse(CamelModel):
+    id: str
+    sha256: str
+    size_bytes: int = Field(alias="sizeBytes")
+    mime: str
+
+
+class XrayMetadata(CamelModel):
+    id: str
+    patient_id: str = Field(alias="patientId")
+    kind: Literal["intake", "monthly"]
+    month: int | None = None
+    mime: str
+    name: str
+    sha256: str
+    size_bytes: int = Field(alias="sizeBytes")
+    created_at: int = Field(alias="createdAt")

--- a/backend/seed_demo.py
+++ b/backend/seed_demo.py
@@ -23,6 +23,38 @@ from backend.models import Xray as XrayRow
 from backend.xray_store import new_xray_id
 
 
+REQUIRED_FORM_FIELDS = (
+    "name",
+    "medicalId",
+    "age",
+    "sex",
+    "province",
+    "registrationGroup",
+    "anatomicalSite",
+    "bacteriologicStatus",
+    "microscopyResult",
+    "sourceOfPatient",
+    "type",
+)
+
+REQUIRED_FEATURE_KEYS = (
+    "age",
+    "daysToTreatment",
+    "year",
+    "sex",
+    "anatomicalSite",
+    "registrationGroup",
+    "bacteriologicStatus",
+    "microscopyResult",
+    "sourceOfPatient",
+    "type",
+    "province",
+    "cityMunicipality",
+    "treatmentHealthFacility",
+    "screeningDiagnosingHealthFacility",
+)
+
+
 def _backend_dir() -> Path:
     return Path(__file__).resolve().parent
 
@@ -99,21 +131,101 @@ def _demo_patients() -> list[_DemoPatient]:
     # Goal: non-empty dashboard + varied risk + trends + adherence.
     base = _now_ms() - 10 * 24 * 60 * 60 * 1000
 
-    def contribs(*items: tuple[str, float, str]) -> list[dict]:
-        return [
-            {"feature": f, "delta": float(d), "direction": direction}
-            for (f, d, direction) in items
+    def contribs(used: dict, prob: float) -> list[dict]:
+        # Mirror production shape: one entry per model feature so the
+        # FeatureContribution page looks complete for seeded records.
+        items: list[dict] = [
+            {
+                "feature": "Age",
+                "delta": 0.05 if int(used.get("age", 0)) >= 45 else 0.02,
+                "direction": "risk" if int(used.get("age", 0)) >= 45 else "protective",
+            },
+            {
+                "feature": "Days to Treatment",
+                "delta": 0.10 if int(used.get("daysToTreatment", 7)) > 7 else 0.03,
+                "direction": "risk" if int(used.get("daysToTreatment", 7)) > 7 else "protective",
+            },
+            {
+                "feature": "Year",
+                "delta": 0.01,
+                "direction": "protective",
+            },
+            {
+                "feature": "Sex",
+                "delta": 0.02,
+                "direction": "risk" if str(used.get("sex", "")).upper() == "M" else "protective",
+            },
+            {
+                "feature": "Anatomical Site",
+                "delta": 0.04,
+                "direction": "risk" if str(used.get("anatomicalSite", "")).upper() == "P" else "protective",
+            },
+            {
+                "feature": "Registration Group",
+                "delta": 0.11 if str(used.get("registrationGroup", "")).upper() != "NEW" else 0.03,
+                "direction": "risk" if str(used.get("registrationGroup", "")).upper() != "NEW" else "protective",
+            },
+            {
+                "feature": "Bacteriologic Status",
+                "delta": 0.08 if str(used.get("bacteriologicStatus", "")).upper() == "POS" else 0.03,
+                "direction": "risk" if str(used.get("bacteriologicStatus", "")).upper() == "POS" else "protective",
+            },
+            {
+                "feature": "Microscopy Result",
+                "delta": 0.12 if str(used.get("microscopyResult", "")).upper() == "POS" else 0.05,
+                "direction": "risk" if str(used.get("microscopyResult", "")).upper() == "POS" else "protective",
+            },
+            {
+                "feature": "Source of Patient",
+                "delta": 0.06 if str(used.get("sourceOfPatient", "")).lower() == "referral" else 0.02,
+                "direction": "risk" if str(used.get("sourceOfPatient", "")).lower() == "referral" else "protective",
+            },
+            {
+                "feature": "Type",
+                "delta": 0.09 if str(used.get("type", "")).lower() in {"retreatment", "relapse"} else 0.03,
+                "direction": "risk" if str(used.get("type", "")).lower() in {"retreatment", "relapse"} else "protective",
+            },
+            {
+                "feature": "Province",
+                "delta": 0.01,
+                "direction": "protective",
+            },
+            {
+                "feature": "City/Municipality",
+                "delta": 0.01,
+                "direction": "protective",
+            },
+            {
+                "feature": "Treatment Facility",
+                "delta": 0.02,
+                "direction": "protective",
+            },
+            {
+                "feature": "Screening Facility",
+                "delta": 0.02,
+                "direction": "protective",
+            },
         ]
+
+        # Nudge top factors by risk profile so cards look realistic.
+        if prob >= 0.7:
+            for item in items:
+                if item["feature"] in {
+                    "Microscopy Result",
+                    "Days to Treatment",
+                    "Registration Group",
+                    "Type",
+                }:
+                    item["delta"] = round(float(item["delta"]) + 0.04, 3)
+
+        items.sort(key=lambda x: float(x["delta"]), reverse=True)
+        return items
 
     def pred(*, label: int, prob: float, ts: int, used: dict) -> dict:
         return {
             "label": int(label),
             "failure_probability": float(prob),
-            "contributions": contribs(
-                ("Adherence", 0.22 if prob > 0.6 else -0.08, "risk" if prob > 0.6 else "protective"),
-                ("Microscopy Result", 0.12 if used.get("microscopyResult") == "POS" else -0.05, "risk" if used.get("microscopyResult") == "POS" else "protective"),
-                ("Days to Treatment", 0.10 if used.get("daysToTreatment", 7) > 7 else -0.02, "risk" if used.get("daysToTreatment", 7) > 7 else "protective"),
-            ),
+            "contributions": contribs(used, prob),
             "features_used": used,
             "timestamp": int(ts),
         }
@@ -224,6 +336,64 @@ def _demo_patients() -> list[_DemoPatient]:
     ]
 
 
+def _validate_demo_patients(demo: list[_DemoPatient]) -> None:
+    for d in demo:
+        if not d.name.strip():
+            raise SystemExit(f"Invalid demo patient {d.id}: missing name")
+
+        # medicalId is required by the form/API shape; we mirror id for seeded records.
+        if not d.id.strip():
+            raise SystemExit("Invalid demo patient: missing id/medicalId")
+
+        missing = [k for k in REQUIRED_FEATURE_KEYS if k not in d.features]
+        if missing:
+            raise SystemExit(f"Invalid demo patient {d.id}: missing required feature keys: {missing}")
+
+        for key in REQUIRED_FORM_FIELDS:
+            value = d.name if key == "name" else (d.id if key == "medicalId" else d.features.get(key))
+            if value is None:
+                raise SystemExit(f"Invalid demo patient {d.id}: required field {key!r} is null")
+            if isinstance(value, str) and not value.strip():
+                raise SystemExit(f"Invalid demo patient {d.id}: required field {key!r} is empty")
+
+        age = d.features.get("age")
+        if not isinstance(age, int) or age <= 0:
+            raise SystemExit(f"Invalid demo patient {d.id}: age must be a positive integer")
+
+        dtt = d.features.get("daysToTreatment")
+        if not isinstance(dtt, int) or dtt < 0:
+            raise SystemExit(
+                f"Invalid demo patient {d.id}: daysToTreatment must be a non-negative integer"
+            )
+
+        for idx, pr in enumerate(d.predictions, start=1):
+            used = pr.get("features_used")
+            if not isinstance(used, dict):
+                raise SystemExit(
+                    f"Invalid demo patient {d.id} prediction #{idx}: features_used missing or invalid"
+                )
+
+            missing_used = [k for k in REQUIRED_FEATURE_KEYS if k not in used]
+            if missing_used:
+                raise SystemExit(
+                    f"Invalid demo patient {d.id} prediction #{idx}: "
+                    f"features_used missing required keys: {missing_used}"
+                )
+
+            used_age = used.get("age")
+            if not isinstance(used_age, int) or used_age <= 0:
+                raise SystemExit(
+                    f"Invalid demo patient {d.id} prediction #{idx}: age must be a positive integer"
+                )
+
+            used_dtt = used.get("daysToTreatment")
+            if not isinstance(used_dtt, int) or used_dtt < 0:
+                raise SystemExit(
+                    f"Invalid demo patient {d.id} prediction #{idx}: "
+                    "daysToTreatment must be a non-negative integer"
+                )
+
+
 def _seed_db(db: Session, *, include_xrays: bool) -> int:
     # Refuse to seed into a non-empty DB unless user reset first.
     existing = db.scalar(select(PatientRow.id).limit(1))
@@ -233,6 +403,7 @@ def _seed_db(db: Session, *, include_xrays: bool) -> int:
         )
 
     demo = _demo_patients()
+    _validate_demo_patients(demo)
     for d in demo:
         p = PatientRow(
             id=d.id,

--- a/backend/seed_demo.py
+++ b/backend/seed_demo.py
@@ -54,6 +54,20 @@ REQUIRED_FEATURE_KEYS = (
     "screeningDiagnosingHealthFacility",
 )
 
+CATEGORICAL_FEATURE_TO_ENCODING = {
+    "sex": "Sex",
+    "anatomicalSite": "Anatomical_Site",
+    "registrationGroup": "Registration_Group",
+    "bacteriologicStatus": "Bacteriologic_Status",
+    "microscopyResult": "Microscopy_Result",
+    "sourceOfPatient": "Source_of_Patient",
+    "type": "Type",
+    "province": "Province",
+    "cityMunicipality": "City_Municipality",
+    "treatmentHealthFacility": "Treatment_Health_Facility",
+    "screeningDiagnosingHealthFacility": "Screening_Diagnosing_Health_Facility",
+}
+
 
 def _backend_dir() -> Path:
     return Path(__file__).resolve().parent
@@ -167,23 +181,33 @@ def _demo_patients() -> list[_DemoPatient]:
             },
             {
                 "feature": "Bacteriologic Status",
-                "delta": 0.08 if str(used.get("bacteriologicStatus", "")).upper() == "POS" else 0.03,
-                "direction": "risk" if str(used.get("bacteriologicStatus", "")).upper() == "POS" else "protective",
+                "delta": 0.08
+                if str(used.get("bacteriologicStatus", "")).startswith("Bacteriologically-confirmed")
+                else 0.03,
+                "direction": "risk"
+                if str(used.get("bacteriologicStatus", "")).startswith("Bacteriologically-confirmed")
+                else "protective",
             },
             {
                 "feature": "Microscopy Result",
-                "delta": 0.12 if str(used.get("microscopyResult", "")).upper() == "POS" else 0.05,
-                "direction": "risk" if str(used.get("microscopyResult", "")).upper() == "POS" else "protective",
+                "delta": 0.12 if str(used.get("microscopyResult", "")) in {"1+", "2+", "3+"} else 0.05,
+                "direction": "risk"
+                if str(used.get("microscopyResult", "")) in {"1+", "2+", "3+"}
+                else "protective",
             },
             {
                 "feature": "Source of Patient",
-                "delta": 0.06 if str(used.get("sourceOfPatient", "")).lower() == "referral" else 0.02,
-                "direction": "risk" if str(used.get("sourceOfPatient", "")).lower() == "referral" else "protective",
+                "delta": 0.06
+                if str(used.get("sourceOfPatient", "")).upper() != "PUBLIC HEALTH CENTER"
+                else 0.02,
+                "direction": "risk"
+                if str(used.get("sourceOfPatient", "")).upper() != "PUBLIC HEALTH CENTER"
+                else "protective",
             },
             {
                 "feature": "Type",
-                "delta": 0.09 if str(used.get("type", "")).lower() in {"retreatment", "relapse"} else 0.03,
-                "direction": "risk" if str(used.get("type", "")).lower() in {"retreatment", "relapse"} else "protective",
+                "delta": 0.09 if str(used.get("type", "")).upper() == "DRTB" else 0.03,
+                "direction": "risk" if str(used.get("type", "")).upper() == "DRTB" else "protective",
             },
             {
                 "feature": "Province",
@@ -242,10 +266,10 @@ def _demo_patients() -> list[_DemoPatient]:
 
     common = {
         "year": 2026,
-        "province": "CAR",
-        "cityMunicipality": "Baguio",
-        "treatmentHealthFacility": "Baguio City Health Center",
-        "screeningDiagnosingHealthFacility": "Baguio General Hospital",
+        "province": "BENGUET",
+        "cityMunicipality": "BAGUIO CITY",
+        "treatmentHealthFacility": "BAGUIO GENERAL HOSPITAL AND MEDICAL CENTER - IDOTS",
+        "screeningDiagnosingHealthFacility": "BAGUIO GENERAL HOSPITAL AND MEDICAL CENTER - IDOTS",
     }
 
     # Note: keep feature keys as client expects (camelCase), because we store JSON and
@@ -257,12 +281,12 @@ def _demo_patients() -> list[_DemoPatient]:
         "sex": "F",
         "anatomicalSite": "P",
         "registrationGroup": "NEW",
-        "bacteriologicStatus": "POS",
-        "microscopyResult": "POS",
-        "sourceOfPatient": "Walk-in",
-        "type": "New",
+        "bacteriologicStatus": "Bacteriologically-confirmed TB",
+        "microscopyResult": "3+",
+        "sourceOfPatient": "PUBLIC HEALTH CENTER",
+        "type": "DSTB",
     }
-    p1_used_m1 = {**p1_features, "microscopyResult": "NEG"}
+    p1_used_m1 = {**p1_features, "microscopyResult": "Negative"}
 
     p2_features = {
         **common,
@@ -271,10 +295,10 @@ def _demo_patients() -> list[_DemoPatient]:
         "sex": "M",
         "anatomicalSite": "P",
         "registrationGroup": "RELAPSE",
-        "bacteriologicStatus": "POS",
-        "microscopyResult": "POS",
-        "sourceOfPatient": "Referral",
-        "type": "Retreatment",
+        "bacteriologicStatus": "Bacteriologically-confirmed TB",
+        "microscopyResult": "2+",
+        "sourceOfPatient": "OTHER PUBLIC FACILITY",
+        "type": "DRTB",
     }
 
     p3_features = {
@@ -284,10 +308,10 @@ def _demo_patients() -> list[_DemoPatient]:
         "sex": "M",
         "anatomicalSite": "EP",
         "registrationGroup": "NEW",
-        "bacteriologicStatus": "NEG",
-        "microscopyResult": "NEG",
-        "sourceOfPatient": "Walk-in",
-        "type": "New",
+        "bacteriologicStatus": "Clinically-diagnosed TB",
+        "microscopyResult": "Negative",
+        "sourceOfPatient": "PUBLIC HEALTH CENTER",
+        "type": "DSTB",
     }
 
     return [
@@ -337,6 +361,15 @@ def _demo_patients() -> list[_DemoPatient]:
 
 
 def _validate_demo_patients(demo: list[_DemoPatient]) -> None:
+    enc_path = _backend_dir().parent / "web-app" / "src" / "data" / "feature_encodings.json"
+    ui_choices: dict[str, set[str]] = {}
+    if enc_path.exists():
+        import json
+
+        enc = json.loads(enc_path.read_text())
+        for feature_key, enc_key in CATEGORICAL_FEATURE_TO_ENCODING.items():
+            ui_choices[feature_key] = set(enc.get("__categorical", {}).get(enc_key, {}).keys())
+
     for d in demo:
         if not d.name.strip():
             raise SystemExit(f"Invalid demo patient {d.id}: missing name")
@@ -355,6 +388,14 @@ def _validate_demo_patients(demo: list[_DemoPatient]) -> None:
                 raise SystemExit(f"Invalid demo patient {d.id}: required field {key!r} is null")
             if isinstance(value, str) and not value.strip():
                 raise SystemExit(f"Invalid demo patient {d.id}: required field {key!r} is empty")
+
+        for feature_key, choices in ui_choices.items():
+            value = d.features.get(feature_key)
+            if value not in choices:
+                raise SystemExit(
+                    f"Invalid demo patient {d.id}: feature {feature_key!r} value {value!r} "
+                    "is not selectable from UI choices"
+                )
 
         age = d.features.get("age")
         if not isinstance(age, int) or age <= 0:
@@ -379,6 +420,14 @@ def _validate_demo_patients(demo: list[_DemoPatient]) -> None:
                     f"Invalid demo patient {d.id} prediction #{idx}: "
                     f"features_used missing required keys: {missing_used}"
                 )
+
+            for feature_key, choices in ui_choices.items():
+                value = used.get(feature_key)
+                if value not in choices:
+                    raise SystemExit(
+                        f"Invalid demo patient {d.id} prediction #{idx}: features_used {feature_key!r} "
+                        f"value {value!r} is not selectable from UI choices"
+                    )
 
             used_age = used.get("age")
             if not isinstance(used_age, int) or used_age <= 0:

--- a/backend/seed_demo.py
+++ b/backend/seed_demo.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from backend import settings
+from backend.db import engine, session_factory
+from backend.models import MonthlyRecord as MonthlyRecordRow
+from backend.models import Patient as PatientRow
+from backend.models import Prediction as PredictionRow
+from backend.models import Xray as XrayRow
+from backend.xray_store import new_xray_id
+
+
+def _backend_dir() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _run_migrations() -> None:
+    cfg = Config(str(_backend_dir() / "alembic.ini"))
+    # Use an absolute script_location so it works regardless of CWD.
+    cfg.set_main_option("script_location", str(_backend_dir() / "alembic"))
+    command.upgrade(cfg, "head")
+
+
+def _require_dev_reset_guard() -> None:
+    # Dev-only safety: force an explicit opt-in env var.
+    if os.getenv("TB_ALLOW_DEV_RESET") != "1":
+        raise SystemExit(
+            "Refusing to reset without TB_ALLOW_DEV_RESET=1 (dev-only safety guard)."
+        )
+
+
+def _is_within(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except Exception:
+        return False
+
+
+def _reset_storage(*, reset_db: bool, reset_xrays: bool) -> None:
+    _require_dev_reset_guard()
+
+    data = settings.data_dir()
+    dbp = settings.db_path()
+    xray_dir = data / "xrays"
+
+    # Safety: only allow deletes inside TB_DATA_DIR.
+    if reset_db and not _is_within(dbp, data):
+        raise SystemExit(f"Refusing to delete DB outside TB_DATA_DIR: {dbp}")
+    if reset_xrays and not _is_within(xray_dir, data):
+        raise SystemExit(f"Refusing to delete X-ray dir outside TB_DATA_DIR: {xray_dir}")
+
+    if reset_db:
+        if dbp.exists():
+            dbp.unlink()
+        # Reset SQLAlchemy engine cache in case this runs in-process.
+        # Import locally to avoid import cycles at module import time.
+        from backend.db import _reset_engine_for_tests
+
+        _reset_engine_for_tests()
+
+    if reset_xrays:
+        if xray_dir.exists():
+            shutil.rmtree(xray_dir)
+        xray_dir.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass(frozen=True)
+class _DemoPatient:
+    id: str
+    name: str
+    features: dict
+    treatment_regimen: str
+    treatment_start_date: str
+    created_at: int
+    predictions: list[dict]
+    monthly_records: list[dict]
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _demo_patients() -> list[_DemoPatient]:
+    # Deterministic, non-PHI demo dataset.
+    # Goal: non-empty dashboard + varied risk + trends + adherence.
+    base = _now_ms() - 10 * 24 * 60 * 60 * 1000
+
+    def contribs(*items: tuple[str, float, str]) -> list[dict]:
+        return [
+            {"feature": f, "delta": float(d), "direction": direction}
+            for (f, d, direction) in items
+        ]
+
+    def pred(*, label: int, prob: float, ts: int, used: dict) -> dict:
+        return {
+            "label": int(label),
+            "failure_probability": float(prob),
+            "contributions": contribs(
+                ("Adherence", 0.22 if prob > 0.6 else -0.08, "risk" if prob > 0.6 else "protective"),
+                ("Microscopy Result", 0.12 if used.get("microscopyResult") == "POS" else -0.05, "risk" if used.get("microscopyResult") == "POS" else "protective"),
+                ("Days to Treatment", 0.10 if used.get("daysToTreatment", 7) > 7 else -0.02, "risk" if used.get("daysToTreatment", 7) > 7 else "protective"),
+            ),
+            "features_used": used,
+            "timestamp": int(ts),
+        }
+
+    def mr(*, month: int, prob: float, ts: int, adherence: str, weight: float | None = None, smear: str | None = None) -> dict:
+        return {
+            "month": int(month),
+            "weight": float(weight) if weight is not None else None,
+            "smear_result": smear,
+            "adherence": adherence,
+            "failure_probability": float(prob),
+            "timestamp": int(ts),
+        }
+
+    common = {
+        "year": 2026,
+        "province": "CAR",
+        "cityMunicipality": "Baguio",
+        "treatmentHealthFacility": "Baguio City Health Center",
+        "screeningDiagnosingHealthFacility": "Baguio General Hospital",
+    }
+
+    # Note: keep feature keys as client expects (camelCase), because we store JSON and
+    # serve it back to the web-app.
+    p1_features = {
+        **common,
+        "age": 29,
+        "daysToTreatment": 2,
+        "sex": "F",
+        "anatomicalSite": "P",
+        "registrationGroup": "NEW",
+        "bacteriologicStatus": "POS",
+        "microscopyResult": "POS",
+        "sourceOfPatient": "Walk-in",
+        "type": "New",
+    }
+    p1_used_m1 = {**p1_features, "microscopyResult": "NEG"}
+
+    p2_features = {
+        **common,
+        "age": 48,
+        "daysToTreatment": 12,
+        "sex": "M",
+        "anatomicalSite": "P",
+        "registrationGroup": "RELAPSE",
+        "bacteriologicStatus": "POS",
+        "microscopyResult": "POS",
+        "sourceOfPatient": "Referral",
+        "type": "Retreatment",
+    }
+
+    p3_features = {
+        **common,
+        "age": 36,
+        "daysToTreatment": 7,
+        "sex": "M",
+        "anatomicalSite": "EP",
+        "registrationGroup": "NEW",
+        "bacteriologicStatus": "NEG",
+        "microscopyResult": "NEG",
+        "sourceOfPatient": "Walk-in",
+        "type": "New",
+    }
+
+    return [
+        _DemoPatient(
+            id="MED-2026-DEMO-0001",
+            name="Demo Patient A",
+            features=p1_features,
+            treatment_regimen="hrze",
+            treatment_start_date="2026-04-01",
+            created_at=base,
+            predictions=[
+                pred(label=1, prob=0.62, ts=base + 1000, used=p1_features),
+                pred(label=0, prob=0.41, ts=base + 35 * 24 * 60 * 60 * 1000, used=p1_used_m1),
+            ],
+            monthly_records=[
+                mr(month=1, prob=0.41, ts=base + 35 * 24 * 60 * 60 * 1000, adherence="full", weight=53.2, smear="NEG"),
+            ],
+        ),
+        _DemoPatient(
+            id="MED-2026-DEMO-0002",
+            name="Demo Patient B",
+            features=p2_features,
+            treatment_regimen="mdr",
+            treatment_start_date="2026-03-15",
+            created_at=base + 2000,
+            predictions=[
+                pred(label=1, prob=0.78, ts=base + 3000, used=p2_features),
+                pred(label=1, prob=0.83, ts=base + 40 * 24 * 60 * 60 * 1000, used=p2_features),
+            ],
+            monthly_records=[
+                mr(month=1, prob=0.83, ts=base + 40 * 24 * 60 * 60 * 1000, adherence="poor", weight=50.1, smear="POS"),
+            ],
+        ),
+        _DemoPatient(
+            id="MED-2026-DEMO-0003",
+            name="Demo Patient C",
+            features=p3_features,
+            treatment_regimen="hrze",
+            treatment_start_date="2026-04-20",
+            created_at=base + 4000,
+            predictions=[
+                pred(label=0, prob=0.18, ts=base + 5000, used=p3_features),
+            ],
+            monthly_records=[],
+        ),
+    ]
+
+
+def _seed_db(db: Session, *, include_xrays: bool) -> int:
+    # Refuse to seed into a non-empty DB unless user reset first.
+    existing = db.scalar(select(PatientRow.id).limit(1))
+    if existing is not None:
+        raise SystemExit(
+            "DB already has patients. Re-run with --reset (and TB_ALLOW_DEV_RESET=1) to seed from scratch."
+        )
+
+    demo = _demo_patients()
+    for d in demo:
+        p = PatientRow(
+            id=d.id,
+            name=d.name,
+            medical_id=d.id,
+            features=d.features,
+            treatment_regimen=d.treatment_regimen,
+            treatment_start_date=d.treatment_start_date,
+            created_at=d.created_at,
+        )
+        for pr in d.predictions:
+            p.predictions.append(
+                PredictionRow(
+                    label=pr["label"],
+                    failure_probability=pr["failure_probability"],
+                    contributions=pr["contributions"],
+                    features_used=pr.get("features_used"),
+                    timestamp=pr["timestamp"],
+                )
+            )
+        for r in d.monthly_records:
+            p.monthly_records.append(
+                MonthlyRecordRow(
+                    month=r["month"],
+                    weight=r.get("weight"),
+                    smear_result=r.get("smear_result"),
+                    adherence=r["adherence"],
+                    failure_probability=r["failure_probability"],
+                    timestamp=r["timestamp"],
+                )
+            )
+        db.add(p)
+
+    if include_xrays:
+        _seed_demo_xrays(db)
+
+    db.commit()
+    return len(demo)
+
+
+def _seed_demo_xrays(db: Session) -> None:
+    # Keep bytes tiny so this is fast and repo-agnostic.
+    # Minimal valid JPEG: SOI + EOI.
+    jpeg_bytes = b"\xff\xd8\xff\xd9"
+    mime = "image/jpeg"
+    ext = ".jpg"
+
+    data = settings.data_dir()
+    xray_dir = data / "xrays"
+    xray_dir.mkdir(parents=True, exist_ok=True)
+
+    def write_xray(*, patient_id: str, kind: str, month: int | None, name: str) -> str:
+        x_id = new_xray_id()
+        dest = xray_dir / f"{x_id}{ext}"
+        dest.write_bytes(jpeg_bytes)
+        sha = hashlib.sha256(jpeg_bytes).hexdigest()
+        now = _now_ms()
+        db.add(
+            XrayRow(
+                id=x_id,
+                patient_id=patient_id,
+                kind=kind,
+                month=month,
+                mime=mime,
+                name=name,
+                sha256=sha,
+                size_bytes=len(jpeg_bytes),
+                rel_path=dest.name,
+                created_at=now,
+            )
+        )
+        return x_id
+
+    # One intake image for patient A.
+    write_xray(
+        patient_id="MED-2026-DEMO-0001",
+        kind="intake",
+        month=None,
+        name="demo_intake.jpg",
+    )
+    # One monthly image for patient B at month 1.
+    write_xray(
+        patient_id="MED-2026-DEMO-0002",
+        kind="monthly",
+        month=1,
+        name="demo_month1.jpg",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m backend.seed_demo",
+        description="Seed demo patient data into the backend SQLite database.",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="Wipe DB file and X-ray directory before seeding (requires TB_ALLOW_DEV_RESET=1).",
+    )
+    parser.add_argument(
+        "--reset-db",
+        action="store_true",
+        help="Wipe DB file before seeding (requires TB_ALLOW_DEV_RESET=1).",
+    )
+    parser.add_argument(
+        "--reset-xrays",
+        action="store_true",
+        help="Wipe X-ray directory before seeding (requires TB_ALLOW_DEV_RESET=1).",
+    )
+    parser.add_argument(
+        "--include-xrays",
+        action="store_true",
+        help="Also seed a small number of demo X-ray files via the filesystem store.",
+    )
+
+    args = parser.parse_args(argv)
+
+    reset_db = bool(args.reset or args.reset_db)
+    reset_xrays = bool(args.reset or args.reset_xrays)
+    if args.reset and not (reset_db and reset_xrays):
+        # defensive, but should always be true
+        reset_db = True
+        reset_xrays = True
+
+    if reset_db or reset_xrays:
+        _reset_storage(reset_db=reset_db, reset_xrays=reset_xrays)
+
+    # Create DB file + tables if needed.
+    engine()  # ensure path created
+    _run_migrations()
+
+    db = session_factory()()
+    try:
+        seeded = _seed_db(db, include_xrays=bool(args.include_xrays))
+    finally:
+        db.close()
+
+    data = settings.data_dir()
+    print(f"Seeded {seeded} demo patients")
+    print(f"DB: {settings.db_path()}")
+    print(f"X-rays dir: {data / 'xrays'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def data_dir() -> Path:
+    # Single-workstation deployment: keep data adjacent to repo by default.
+    p = Path(os.getenv("TB_DATA_DIR", str(repo_root() / "data"))).resolve()
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def db_path() -> Path:
+    return Path(os.getenv("TB_DB_PATH", str(data_dir() / "tb_cdss.sqlite3"))).resolve()
+
+
+def sqlalchemy_database_url() -> str:
+    # Use sqlite+pysqlite so SQLAlchemy doesn't try aiosqlite.
+    return f"sqlite+pysqlite:///{db_path()}"
+
+
+def max_upload_bytes() -> int:
+    # 25MB default; override via env for larger DICOM-derived exports.
+    return int(os.getenv("TB_MAX_UPLOAD_BYTES", str(25 * 1024 * 1024)))

--- a/backend/tests/test_migrations_and_api.py
+++ b/backend/tests/test_migrations_and_api.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def tmp_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "data"
+    monkeypatch.setenv("TB_DATA_DIR", str(d))
+    monkeypatch.setenv("TB_DB_PATH", str(d / "test.sqlite3"))
+    return d
+
+
+def _run_migrations() -> None:
+    from alembic import command
+    from alembic.config import Config
+    from pathlib import Path
+
+    backend_dir = Path(__file__).resolve().parents[1]
+    cfg = Config(str(backend_dir / "alembic.ini"))
+    # Use an absolute script_location so tests pass regardless of CWD.
+    cfg.set_main_option("script_location", str(backend_dir / "alembic"))
+    command.upgrade(cfg, "head")
+
+
+def test_migrations_apply_on_clean_db(tmp_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    # Ensure a clean DB
+    db_path = Path(os.environ["TB_DB_PATH"])
+    if db_path.exists():
+        db_path.unlink()
+
+    _run_migrations()
+    assert db_path.exists()
+
+
+def test_patient_create_and_fetch_shape(tmp_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    _run_migrations()
+
+    # Import after env vars are set so the backend uses the test DB.
+    from backend.db import _reset_engine_for_tests
+    _reset_engine_for_tests()
+    from backend.main import app
+
+    client = TestClient(app)
+
+    body = {
+        "id": "MED-2026-0001",
+        "name": "Alice",
+        "medicalId": "MED-2026-0001",
+        "features": {
+            "age": 35,
+            "daysToTreatment": 7,
+            "year": 2026,
+            "sex": "M",
+            "anatomicalSite": "P",
+            "registrationGroup": "NEW",
+            "bacteriologicStatus": "POS",
+            "microscopyResult": "POS",
+            "sourceOfPatient": "Walk-in",
+            "type": "New",
+            "province": "CAR",
+            "cityMunicipality": "Baguio",
+            "treatmentHealthFacility": "",
+            "screeningDiagnosingHealthFacility": "",
+        },
+        "createdAt": 1710000000000,
+        "predictions": [],
+        "monthlyRecords": [],
+    }
+
+    # POST /api/patients expects PatientCreate (no predictions/monthlyRecords)
+    create_body = {
+        "id": body["id"],
+        "name": body["name"],
+        "medicalId": body["medicalId"],
+        "features": body["features"],
+        "createdAt": body["createdAt"],
+    }
+
+    res = client.post("/api/patients", json=create_body)
+    assert res.status_code == 200
+    created = res.json()
+
+    assert created["id"] == "MED-2026-0001"
+    assert created["medicalId"] == "MED-2026-0001"
+    assert created["features"]["daysToTreatment"] == 7
+    assert created["predictions"] == []
+    assert created["monthlyRecords"] == []
+    assert created.get("intakeXrayIds") in (None, [])
+
+    res2 = client.get("/api/patients/MED-2026-0001")
+    assert res2.status_code == 200
+    fetched = res2.json()
+    assert fetched["id"] == "MED-2026-0001"
+
+
+def test_xray_upload_and_file_fetch(tmp_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    _run_migrations()
+    from backend.db import _reset_engine_for_tests
+    _reset_engine_for_tests()
+    from backend.main import app
+
+    client = TestClient(app)
+
+    # Create patient
+    res = client.post(
+        "/api/patients",
+        json={
+            "id": "MED-2026-0002",
+            "name": "Bob",
+            "medicalId": "MED-2026-0002",
+            "features": {
+                "age": 40,
+                "daysToTreatment": 7,
+                "year": 2026,
+                "sex": "M",
+                "anatomicalSite": "P",
+                "registrationGroup": "NEW",
+                "bacteriologicStatus": "POS",
+                "microscopyResult": "POS",
+                "sourceOfPatient": "Walk-in",
+                "type": "New",
+                "province": "CAR",
+                "cityMunicipality": "Baguio",
+                "treatmentHealthFacility": "",
+                "screeningDiagnosingHealthFacility": "",
+            },
+            "createdAt": 1710000000000,
+        },
+    )
+    assert res.status_code == 200
+
+    # Minimal valid JPEG: SOI + EOI.
+    jpeg_bytes = b"\xff\xd8\xff\xd9"
+    files = {"file": ("test.jpg", jpeg_bytes, "image/jpeg")}
+    res2 = client.post(
+        "/api/xrays?patient_id=MED-2026-0002&kind=intake",
+        files=files,
+    )
+    assert res2.status_code == 200
+    x = res2.json()
+    assert x["id"].startswith("xr_")
+    assert x["mime"] == "image/jpeg"
+    assert x["sizeBytes"] == len(jpeg_bytes)
+
+    # Fetch file
+    res3 = client.get(f"/api/xrays/{x['id']}/file")
+    assert res3.status_code == 200
+    assert res3.headers["content-type"].startswith("image/jpeg")
+    assert res3.content == jpeg_bytes

--- a/backend/tests/test_seed_demo.py
+++ b/backend/tests/test_seed_demo.py
@@ -1,11 +1,62 @@
 from __future__ import annotations
 
 import os
+import json
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+
+REQUIRED_FORM_FIELDS = (
+    "name",
+    "medicalId",
+    "age",
+    "sex",
+    "province",
+    "registrationGroup",
+    "anatomicalSite",
+    "bacteriologicStatus",
+    "microscopyResult",
+    "sourceOfPatient",
+    "type",
+)
+
+REQUIRED_FEATURE_KEYS = (
+    "age",
+    "daysToTreatment",
+    "year",
+    "sex",
+    "anatomicalSite",
+    "registrationGroup",
+    "bacteriologicStatus",
+    "microscopyResult",
+    "sourceOfPatient",
+    "type",
+    "province",
+    "cityMunicipality",
+    "treatmentHealthFacility",
+    "screeningDiagnosingHealthFacility",
+)
+
+EXPECTED_CONTRIBUTION_FEATURES = {
+    "Age",
+    "Days to Treatment",
+    "Year",
+    "Sex",
+    "Anatomical Site",
+    "Registration Group",
+    "Bacteriologic Status",
+    "Microscopy Result",
+    "Source of Patient",
+    "Type",
+    "Province",
+    "City/Municipality",
+    "Treatment Facility",
+    "Screening Facility",
+}
 
 
 @pytest.fixture()
@@ -58,3 +109,85 @@ def test_seed_demo_seeds_and_is_repeatable_with_reset(tmp_data_dir: Path):
     # Re-run with reset should succeed again.
     r3 = _run_seed("--reset", env={"TB_ALLOW_DEV_RESET": "1"})
     assert r3.returncode == 0, r3.stdout + r3.stderr
+
+
+def test_seeded_rows_include_required_form_fields(tmp_data_dir: Path):
+    r = _run_seed("--reset", env={"TB_ALLOW_DEV_RESET": "1"})
+    assert r.returncode == 0, r.stdout + r.stderr
+
+    db_path = Path(os.environ["TB_DB_PATH"])
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT id, name, medical_id, features FROM patients").fetchall()
+    finally:
+        conn.close()
+
+    assert rows
+    for pid, name, medical_id, features_json in rows:
+        assert str(name).strip()
+        assert str(medical_id).strip()
+        features = json.loads(features_json)
+
+        for key in REQUIRED_FEATURE_KEYS:
+            assert key in features, f"{pid}: missing feature key {key}"
+
+        for key in REQUIRED_FORM_FIELDS:
+            value = name if key == "name" else (medical_id if key == "medicalId" else features[key])
+            assert value is not None
+            if isinstance(value, str):
+                assert value.strip(), f"{pid}: empty required field {key}"
+
+
+def test_seeded_predictions_include_full_feature_contributions(tmp_data_dir: Path):
+    r = _run_seed("--reset", env={"TB_ALLOW_DEV_RESET": "1"})
+    assert r.returncode == 0, r.stdout + r.stderr
+
+    db_path = Path(os.environ["TB_DB_PATH"])
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT patient_id, contributions FROM predictions").fetchall()
+    finally:
+        conn.close()
+
+    assert rows
+    for patient_id, contributions_json in rows:
+        contributions = json.loads(contributions_json)
+        assert len(contributions) == len(EXPECTED_CONTRIBUTION_FEATURES), (
+            f"{patient_id}: expected {len(EXPECTED_CONTRIBUTION_FEATURES)} contributions, "
+            f"got {len(contributions)}"
+        )
+
+        names = {c["feature"] for c in contributions}
+        assert names == EXPECTED_CONTRIBUTION_FEATURES, (
+            f"{patient_id}: contribution features mismatch: {names}"
+        )
+
+        assert all(c.get("direction") in {"risk", "protective"} for c in contributions), (
+            f"{patient_id}: contribution direction values must be risk/protective"
+        )
+
+        assert all(
+            isinstance(c.get("delta"), (int, float)) and float(c["delta"]) >= 0
+            for c in contributions
+        ), f"{patient_id}: contribution deltas must be non-negative numeric values"
+
+
+def test_seeded_prediction_features_used_include_required_keys(tmp_data_dir: Path):
+    r = _run_seed("--reset", env={"TB_ALLOW_DEV_RESET": "1"})
+    assert r.returncode == 0, r.stdout + r.stderr
+
+    db_path = Path(os.environ["TB_DB_PATH"])
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT patient_id, features_used FROM predictions").fetchall()
+    finally:
+        conn.close()
+
+    assert rows
+    for patient_id, features_used_json in rows:
+        used = json.loads(features_used_json)
+        for key in REQUIRED_FEATURE_KEYS:
+            assert key in used, f"{patient_id}: features_used missing key {key}"
+
+        assert isinstance(used.get("age"), int) and used["age"] > 0
+        assert isinstance(used.get("daysToTreatment"), int) and used["daysToTreatment"] >= 0

--- a/backend/tests/test_seed_demo.py
+++ b/backend/tests/test_seed_demo.py
@@ -58,6 +58,20 @@ EXPECTED_CONTRIBUTION_FEATURES = {
     "Screening Facility",
 }
 
+CATEGORICAL_FEATURE_TO_ENCODING = {
+    "sex": "Sex",
+    "anatomicalSite": "Anatomical_Site",
+    "registrationGroup": "Registration_Group",
+    "bacteriologicStatus": "Bacteriologic_Status",
+    "microscopyResult": "Microscopy_Result",
+    "sourceOfPatient": "Source_of_Patient",
+    "type": "Type",
+    "province": "Province",
+    "cityMunicipality": "City_Municipality",
+    "treatmentHealthFacility": "Treatment_Health_Facility",
+    "screeningDiagnosingHealthFacility": "Screening_Diagnosing_Health_Facility",
+}
+
 
 @pytest.fixture()
 def tmp_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -191,3 +205,30 @@ def test_seeded_prediction_features_used_include_required_keys(tmp_data_dir: Pat
 
         assert isinstance(used.get("age"), int) and used["age"] > 0
         assert isinstance(used.get("daysToTreatment"), int) and used["daysToTreatment"] >= 0
+
+
+def test_seeded_categorical_values_are_selectable_in_ui(tmp_data_dir: Path):
+    r = _run_seed("--reset", env={"TB_ALLOW_DEV_RESET": "1"})
+    assert r.returncode == 0, r.stdout + r.stderr
+
+    repo_root = Path(__file__).resolve().parents[2]
+    enc = json.loads((repo_root / "web-app" / "src" / "data" / "feature_encodings.json").read_text())
+    allowed = {
+        feature_key: set(enc["__categorical"][enc_key].keys())
+        for feature_key, enc_key in CATEGORICAL_FEATURE_TO_ENCODING.items()
+    }
+
+    db_path = Path(os.environ["TB_DB_PATH"])
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute("SELECT id, features FROM patients").fetchall()
+    finally:
+        conn.close()
+
+    assert rows
+    for patient_id, features_json in rows:
+        features = json.loads(features_json)
+        for feature_key, choices in allowed.items():
+            assert features[feature_key] in choices, (
+                f"{patient_id}: {feature_key}={features[feature_key]!r} not selectable from UI"
+            )

--- a/backend/tests/test_seed_demo.py
+++ b/backend/tests/test_seed_demo.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    d = tmp_path / "data"
+    monkeypatch.setenv("TB_DATA_DIR", str(d))
+    monkeypatch.setenv("TB_DB_PATH", str(d / "test.sqlite3"))
+    return d
+
+
+def _run_seed(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    e = os.environ.copy()
+    if env:
+        e.update(env)
+    repo_root = Path(__file__).resolve().parents[2]
+    return subprocess.run(
+        [sys.executable, "-m", "backend.seed_demo", *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        env=e,
+        cwd=str(repo_root),
+    )
+
+
+def test_seed_demo_requires_explicit_reset_guard(tmp_data_dir: Path):
+    # Reset is dev-only and must be explicitly enabled.
+    r = _run_seed("--reset")
+    assert r.returncode != 0
+    assert "TB_ALLOW_DEV_RESET=1" in (r.stdout + r.stderr)
+
+
+def test_seed_demo_seeds_and_is_repeatable_with_reset(tmp_data_dir: Path):
+    r1 = _run_seed("--reset", "--include-xrays", env={"TB_ALLOW_DEV_RESET": "1"})
+    assert r1.returncode == 0, r1.stdout + r1.stderr
+    assert "Seeded 3 demo patients" in r1.stdout
+
+    db_path = Path(os.environ["TB_DB_PATH"])
+    assert db_path.exists()
+    xrays_dir = tmp_data_dir / "xrays"
+    assert xrays_dir.exists()
+    # Expect at least one seeded file.
+    assert any(p.suffix == ".jpg" for p in xrays_dir.iterdir())
+
+    # Re-run without reset should refuse to seed into a non-empty DB.
+    r2 = _run_seed()
+    assert r2.returncode != 0
+    assert "DB already has patients" in (r2.stdout + r2.stderr)
+
+    # Re-run with reset should succeed again.
+    r3 = _run_seed("--reset", env={"TB_ALLOW_DEV_RESET": "1"})
+    assert r3.returncode == 0, r3.stdout + r3.stderr

--- a/backend/xray_store.py
+++ b/backend/xray_store.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+import tempfile
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile
+
+
+ALLOWED_MIME = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+}
+
+
+def _sniff_mime(first_bytes: bytes) -> str | None:
+    if len(first_bytes) >= 3 and first_bytes[0:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if len(first_bytes) >= 8 and first_bytes[0:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if len(first_bytes) >= 12 and first_bytes[0:4] == b"RIFF" and first_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def new_xray_id() -> str:
+    return f"xr_{int.from_bytes(os.urandom(6), 'big')}_{secrets.token_hex(4)}"
+
+
+class XrayFileStore:
+    def __init__(self, root: Path):
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    async def save(self, *, xray_id: str, file: UploadFile, max_bytes: int) -> tuple[str, str, int, str]:
+        content_type = file.content_type or ""
+        if content_type not in ALLOWED_MIME:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported file type: {content_type}. Allowed: JPEG, PNG, WebP.",
+            )
+
+        ext = ALLOWED_MIME[content_type]
+        dest = self.root / f"{xray_id}{ext}"
+
+        # Atomic write: write temp file in same dir then replace.
+        tmp_fd, tmp_name = tempfile.mkstemp(prefix=f".{xray_id}.", dir=str(self.root))
+        tmp = Path(tmp_name)
+        sha = hashlib.sha256()
+        size = 0
+
+        try:
+            with os.fdopen(tmp_fd, "wb") as out:
+                first = await file.read(64 * 1024)
+                if not first:
+                    raise HTTPException(status_code=400, detail="Empty upload")
+
+                sniffed = _sniff_mime(first)
+                if sniffed != content_type:
+                    raise HTTPException(status_code=400, detail="File bytes do not match declared MIME")
+
+                out.write(first)
+                sha.update(first)
+                size += len(first)
+                if size > max_bytes:
+                    raise HTTPException(status_code=413, detail="Upload too large")
+
+                while True:
+                    chunk = await file.read(64 * 1024)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    sha.update(chunk)
+                    size += len(chunk)
+                    if size > max_bytes:
+                        raise HTTPException(status_code=413, detail="Upload too large")
+
+                out.flush()
+                os.fsync(out.fileno())
+
+            tmp.replace(dest)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"Failed to store X-ray: {type(exc).__name__}")
+        finally:
+            try:
+                if tmp.exists() and tmp != dest:
+                    tmp.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+        rel_path = dest.name
+        return rel_path, sha.hexdigest(), size, content_type

--- a/dev.sh
+++ b/dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dev.sh — start MedGemma backend + React frontend with a live dashboard
+# dev.sh — start backend API + React frontend with a live dashboard
 # Usage: ./dev.sh
 
 set -euo pipefail
@@ -69,7 +69,7 @@ if [[ ! -f "$MODEL" ]]; then
 fi
 
 # ── install deps if needed ────────────────────────────────────────────────────
-if ! python3 -c "import llama_cpp" &>/dev/null 2>&1; then
+if ! python3 -c "import fastapi,uvicorn,llama_cpp,sqlalchemy,alembic" &>/dev/null 2>&1; then
   log "Installing backend dependencies..."
   pip install -r "$BACKEND/requirements.txt" --quiet
   ok "Backend dependencies installed"
@@ -81,9 +81,9 @@ if [[ ! -d "$WEBAPP/node_modules" ]]; then
 fi
 
 # ── start processes (output → log files) ─────────────────────────────────────
-log "Starting MedGemma backend on :$BACKEND_PORT  (log → logs/backend.log)"
-cd "$BACKEND"
-uvicorn main:app --port "$BACKEND_PORT" --log-level info >> "$BACKEND_LOG" 2>&1 &
+log "Starting backend API on :$BACKEND_PORT  (log → logs/backend.log)"
+cd "$ROOT"
+uvicorn backend.main:app --port "$BACKEND_PORT" --log-level info >> "$BACKEND_LOG" 2>&1 &
 BACKEND_PID=$!
 
 log "Starting React frontend on :$FRONTEND_PORT  (log → logs/frontend.log)"
@@ -189,7 +189,7 @@ draw_dashboard() {
 
   echo ""
   echo -e "  ${BOLD}${CYAN}SERVICES${RESET}"
-  printf "  %-22s %b\n" "MedGemma Backend" "$be_badge"
+  printf "  %-22s %b\n" "Backend API"      "$be_badge"
   printf "  %-22s %b\n" "React Frontend"   "$fe_badge"
 
   echo ""

--- a/web-app/src/lib/storage.ts
+++ b/web-app/src/lib/storage.ts
@@ -1,5 +1,4 @@
 import type { PatientFeatures, ContributionResult } from './inference'
-import { putXray } from './xrayStore'
 
 export interface MonthlyRecord {
   month: number
@@ -34,95 +33,106 @@ export interface Patient {
   intakeXrayIds?: string[]
 }
 
-const STORAGE_KEY = 'tb_patients'
-
-function load(): Patient[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    return raw ? JSON.parse(raw) : []
-  } catch {
-    return []
-  }
+async function json<T>(res: Response): Promise<T> {
+  const text = await res.text()
+  return text ? (JSON.parse(text) as T) : (null as T)
 }
 
-// SECURITY NOTE: Patient structured data is stored unencrypted in localStorage.
-// Deploy only on a dedicated, access-controlled clinical workstation. See xrayStore.ts.
-function save(patients: Patient[]): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(patients))
-  } catch (e) {
-    // QuotaExceededError — alert clinician so data loss is visible
-    console.error('localStorage quota exceeded — patient data may not have been saved.', e)
-    alert('Storage limit reached. Some patient data could not be saved. Please export records and clear storage.')
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, init)
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(body || res.statusText || `HTTP ${res.status}`)
   }
+  return json<T>(res)
 }
 
-export function getAllPatients(): Patient[] {
-  return load().sort((a, b) => {
+export async function getAllPatients(): Promise<Patient[]> {
+  const patients = await api<Patient[]>('/api/patients')
+  return patients.sort((a, b) => {
     const aRisk = a.predictions.at(-1)?.failureProbability ?? 0
     const bRisk = b.predictions.at(-1)?.failureProbability ?? 0
     return bRisk - aRisk
   })
 }
 
-export function getPatient(id: string): Patient | null {
-  return load().find(p => p.id === id) ?? null
-}
-
-export function savePatient(patient: Patient): void {
-  const patients = load()
-  const idx = patients.findIndex(p => p.id === patient.id)
-  if (idx >= 0) {
-    patients[idx] = patient
-  } else {
-    patients.push(patient)
-  }
-  save(patients)
-}
-
-export function addPrediction(id: string, record: PredictionRecord): void {
-  const patients = load()
-  const p = patients.find(p => p.id === id)
-  if (p) {
-    p.predictions.push(record)
-    save(patients)
+export async function getPatient(id: string): Promise<Patient | null> {
+  try {
+    return await api<Patient>(`/api/patients/${encodeURIComponent(id)}`)
+  } catch (e) {
+    if (e instanceof Error && e.message.includes('404')) return null
+    throw e
   }
 }
 
-export function addMonthlyRecord(id: string, record: MonthlyRecord): void {
-  const patients = load()
-  const p = patients.find(p => p.id === id)
-  if (p) {
-    p.monthlyRecords.push(record)
-    save(patients)
-  }
+export async function savePatient(patient: Patient): Promise<void> {
+  await api<Patient>(`/api/patients/${encodeURIComponent(patient.id)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patient),
+    },
+  )
+}
+
+export async function addPrediction(id: string, record: PredictionRecord): Promise<void> {
+  await api<{ ok: true }>(`/api/patients/${encodeURIComponent(id)}/predictions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(record),
+  })
+}
+
+export async function addMonthlyRecord(id: string, record: MonthlyRecord): Promise<void> {
+  await api<{ ok: true }>(`/api/patients/${encodeURIComponent(id)}/monthly-records`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(record),
+  })
 }
 
 export function generateId(): string {
   return `MED-${new Date().getFullYear()}-${Math.floor(Math.random() * 9000 + 1000)}`
 }
 
-// TODO(server): replace putXray calls below with server upload; see xrayStore.ts
-
 export async function attachIntakeXrays(patientId: string, files: File[]): Promise<void> {
   if (files.length === 0) return
-  // Load and verify patient exists before writing blobs to IndexedDB
-  const patients = load()
-  const p = patients.find(p => p.id === patientId)
+
+  // Ensure patient exists.
+  const p = await getPatient(patientId)
   if (!p) return
-  const ids = await Promise.all(files.map(f => putXray(f)))
-  p.intakeXrayIds = [...(p.intakeXrayIds ?? []), ...ids]
-  save(patients)
+
+  await Promise.all(
+    files.map(async file => {
+      const form = new FormData()
+      form.append('file', file)
+      await api(`/api/xrays?patient_id=${encodeURIComponent(patientId)}&kind=intake`, {
+        method: 'POST',
+        body: form,
+      })
+    }),
+  )
 }
 
 export async function attachMonthlyXrays(patientId: string, month: number, files: File[]): Promise<void> {
   if (files.length === 0) return
-  // Load and verify both patient and monthly record exist before writing blobs
-  const patients = load()
-  const p = patients.find(p => p.id === patientId)
+
+  // Ensure patient and record exist.
+  const p = await getPatient(patientId)
   const record = p?.monthlyRecords.find(r => r.month === month)
   if (!p || !record) return
-  const ids = await Promise.all(files.map(f => putXray(f)))
-  record.xrayIds = [...(record.xrayIds ?? []), ...ids]
-  save(patients)
+
+  await Promise.all(
+    files.map(async file => {
+      const form = new FormData()
+      form.append('file', file)
+      await api(
+        `/api/xrays?patient_id=${encodeURIComponent(patientId)}&kind=monthly&month=${encodeURIComponent(String(month))}`,
+        {
+          method: 'POST',
+          body: form,
+        },
+      )
+    }),
+  )
 }

--- a/web-app/src/lib/useXrayUrl.ts
+++ b/web-app/src/lib/useXrayUrl.ts
@@ -1,36 +1,6 @@
-import { useEffect, useState } from 'react'
-import { getXray } from './xrayStore'
-
-// Returns a revocable object URL for a stored X-ray blob.
-// Returns null while loading or if the id is not found.
-// The URL is automatically revoked when the component unmounts or id changes.
+// Server-backed X-ray URL.
+// Returns null when id is missing.
 export function useXrayUrl(id: string | undefined): string | null {
-  const [url, setUrl] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!id) return
-    let objectUrl: string | null = null
-    let cancelled = false
-
-    getXray(id)
-      .then(record => {
-        if (cancelled || !record) return
-        objectUrl = URL.createObjectURL(record.blob)
-        setUrl(objectUrl)
-      })
-      .catch(() => {
-        // Silently ignore — missing blob renders as an empty thumbnail
-      })
-
-    return () => {
-      cancelled = true
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl)
-        objectUrl = null
-      }
-      setUrl(null)
-    }
-  }, [id])
-
-  return url
+  if (!id) return null
+  return `/api/xrays/${encodeURIComponent(id)}/file`
 }

--- a/web-app/src/pages/Dashboard.tsx
+++ b/web-app/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { LayoutDashboard, ArrowDown, ArrowUp, Minus, HelpCircle } from 'lucide-react'
 import { getAllPatients } from '../lib/storage'
 import { riskLabel, riskColor } from '../components/RiskBadge'
@@ -12,9 +12,38 @@ function latestProb(p: Patient): number {
 }
 
 export function Dashboard() {
-  const patients = getAllPatients()
-  const total = patients.length
+  const [patients, setPatients] = useState<Patient[] | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [adhHintOpen, setAdhHintOpen] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const list = await getAllPatients()
+        if (!cancelled) setPatients(list)
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (patients === null) {
+    return (
+      <div className="min-h-screen bg-bg flex flex-col">
+        <AppHeader title="Dashboard" />
+        <div className="flex-1 px-4 lg:px-8 pt-10 pb-8 w-full">
+          <p className="text-sm text-ink-muted">Loading dashboard…</p>
+          {loadError && <p className="text-sm text-risk-high mt-2">{loadError}</p>}
+        </div>
+      </div>
+    )
+  }
+
+  const total = patients.length
 
   const highRisk = patients.filter(p => riskLabel(latestProb(p)) === 'HIGH').length
   const medRisk  = patients.filter(p => riskLabel(latestProb(p)) === 'MED').length

--- a/web-app/src/pages/DiagnosticResult.tsx
+++ b/web-app/src/pages/DiagnosticResult.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { BarChart3, Info } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
@@ -7,21 +8,72 @@ import { PageFooter } from '../components/PageFooter'
 import { getPatient } from '../lib/storage'
 import type { ContributionResult } from '../lib/inference'
 import { ClinicalInterpretation } from '../components/ClinicalInterpretation'
+import type { Patient } from '../lib/storage'
 
 export function DiagnosticResult() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
   const location = useLocation()
 
-  const patient = id ? getPatient(id) : null
+  const [patient, setPatient] = useState<Patient | null>(null)
+  const [loadingPatient, setLoadingPatient] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
   const result: ContributionResult | null = location.state?.result ?? null
   const prob = result?.failureProbability ?? patient?.predictions.at(-1)?.failureProbability ?? 0
   const isHighRisk = prob >= 0.6  // matches riskLabel() HIGH threshold in RiskBadge.tsx
+
+  useEffect(() => {
+    let cancelled = false
+    if (!id) {
+      setLoadingPatient(false)
+      setPatient(null)
+      return
+    }
+    setLoadingPatient(true)
+    ;(async () => {
+      try {
+        const p = await getPatient(id)
+        if (!cancelled) setPatient(p)
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoadingPatient(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [id])
 
   const riskGradient = isHighRisk
     ? 'bg-gradient-to-br from-risk-high/5 to-risk-high/15 border-risk-high/30'
     : 'bg-gradient-to-br from-risk-low/5 to-risk-low/15 border-risk-low/30'
   const riskText = isHighRisk ? 'text-risk-high' : 'text-risk-low'
+
+  if (loadingPatient) {
+    return (
+      <div className="min-h-screen bg-bg flex flex-col">
+        <AppHeader />
+        <StepProgress steps={5} current={4} />
+        <div className="flex-1 px-4 lg:px-8 pt-10 pb-6 w-full max-w-4xl mx-auto">
+          <p className="text-sm text-ink-muted">Loading patient…</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen bg-bg flex flex-col">
+        <AppHeader />
+        <StepProgress steps={5} current={4} />
+        <div className="flex-1 px-4 lg:px-8 pt-10 pb-6 w-full max-w-4xl mx-auto">
+          <p className="text-sm text-risk-high">{loadError}</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-bg flex flex-col">

--- a/web-app/src/pages/FeatureContribution.tsx
+++ b/web-app/src/pages/FeatureContribution.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Info } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
@@ -8,6 +9,7 @@ import { featureKeyFor } from '../lib/inference'
 import { PageFooter } from '../components/PageFooter'
 import { ClinicalInterpretation } from '../components/ClinicalInterpretation'
 import type { ContributionResult } from '../lib/inference'
+import type { Patient } from '../lib/storage'
 
 function formatValue(displayName: string, raw: unknown): string | undefined {
   if (raw === undefined || raw === null || raw === '') return undefined
@@ -18,8 +20,50 @@ function formatValue(displayName: string, raw: unknown): string | undefined {
 export function FeatureContribution() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
-  const patient = id ? getPatient(id) : null
+  const [patient, setPatient] = useState<Patient | null>(null)
+  const [loadingPatient, setLoadingPatient] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!id) {
+      setLoadingPatient(false)
+      setPatient(null)
+      return
+    }
+    setLoadingPatient(true)
+    ;(async () => {
+      try {
+        const p = await getPatient(id)
+        if (!cancelled) setPatient(p)
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoadingPatient(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
   const latest  = patient?.predictions.at(-1)
+
+  if (loadingPatient) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">Loading patient…</p>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">{loadError}</p>
+      </div>
+    )
+  }
 
   if (!patient || !latest) {
     return (

--- a/web-app/src/pages/Home.tsx
+++ b/web-app/src/pages/Home.tsx
@@ -1,15 +1,46 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Stethoscope, UserPlus } from 'lucide-react'
 import { getAllPatients } from '../lib/storage'
 import { AppHeader } from '../components/AppHeader'
 import { PatientCard } from '../components/PatientCard'
 import { riskLabel } from '../components/RiskBadge'
+import type { Patient } from '../lib/storage'
 
 export function Home() {
   const navigate = useNavigate()
-  const patients = getAllPatients()
+  const [patients, setPatients] = useState<Patient[] | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const list = await getAllPatients()
+        if (!cancelled) setPatients(list)
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (patients === null) {
+    return (
+      <div className="min-h-screen bg-bg flex flex-col">
+        <AppHeader />
+        <div className="flex-1 px-4 lg:px-8 pt-10 pb-24 lg:pb-8 w-full max-w-5xl mx-auto">
+          <p className="text-sm text-ink-muted">Loading patients…</p>
+          {loadError && (
+            <p className="text-sm text-risk-high mt-2">{loadError}</p>
+          )}
+        </div>
+      </div>
+    )
+  }
 
   const filtered = query.trim()
     ? patients.filter(p =>

--- a/web-app/src/pages/MonthlyCheckin.tsx
+++ b/web-app/src/pages/MonthlyCheckin.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Check, AlertTriangle, X } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
@@ -6,13 +6,39 @@ import { XrayUploadField } from '../components/XrayUploadField'
 import { getChoices, predictWithContributions } from '../lib/inference'
 import { getPatient, addMonthlyRecord, addPrediction, attachMonthlyXrays } from '../lib/storage'
 import { PageFooter } from '../components/PageFooter'
+import type { Patient } from '../lib/storage'
 
 type Adherence = 'full' | 'partial' | 'poor'
 
 export function MonthlyCheckin() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
-  const patient = id ? getPatient(id) : null
+  const [patient, setPatient] = useState<Patient | null>(null)
+  const [loadingPatient, setLoadingPatient] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!id) {
+      setLoadingPatient(false)
+      setPatient(null)
+      return
+    }
+    setLoadingPatient(true)
+    ;(async () => {
+      try {
+        const p = await getPatient(id)
+        if (!cancelled) setPatient(p)
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoadingPatient(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [id])
 
   const [weight, setWeight] = useState('')
   const [smearResult, setSmearResult] = useState('')
@@ -34,25 +60,26 @@ export function MonthlyCheckin() {
       const result = await predictWithContributions(updatedFeatures)
 
       const parsedWeight = parseFloat(weight)
-      addMonthlyRecord(id, {
+      const now = Date.now()
+      await addMonthlyRecord(id, {
         month: monthNumber,
         weight: Number.isFinite(parsedWeight) ? parsedWeight : undefined,
         smearResult: smearResult || undefined,
         adherence,
         failureProbability: result.failureProbability,
-        timestamp: Date.now(),
+        timestamp: now,
       })
 
       if (xrayFiles.length > 0) {
         await attachMonthlyXrays(id, monthNumber, xrayFiles)
       }
 
-      addPrediction(id, {
+      await addPrediction(id, {
         label: result.label,
         failureProbability: result.failureProbability,
         contributions: result.contributions,
         featuresUsed: updatedFeatures,
-        timestamp: Date.now(),
+        timestamp: now,
       })
 
       navigate(`/patient/${id}/risk-update`, { state: { result, monthNumber } })
@@ -77,6 +104,39 @@ export function MonthlyCheckin() {
   ]
 
   const inputCls = 'w-full min-h-[44px] border border-border rounded-xl px-3 py-2.5 text-sm text-ink-base bg-surface placeholder-ink-muted focus:border-primary outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1'
+
+  if (loadingPatient) {
+    return (
+      <div className="min-h-screen bg-bg flex flex-col">
+        <AppHeader backLabel="Back" onBack={() => navigate(-1)} />
+        <div className="flex-1 px-4 lg:px-8 pt-10 pb-6 w-full max-w-3xl mx-auto">
+          <p className="text-sm text-ink-muted">Loading patient…</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen bg-bg flex flex-col">
+        <AppHeader backLabel="Back" onBack={() => navigate(-1)} />
+        <div className="flex-1 px-4 lg:px-8 pt-10 pb-6 w-full max-w-3xl mx-auto">
+          <p className="text-sm text-risk-high">{loadError}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!patient || !id) {
+    return (
+      <div className="min-h-screen bg-bg flex flex-col">
+        <AppHeader backLabel="Back" onBack={() => navigate(-1)} />
+        <div className="flex-1 px-4 lg:px-8 pt-10 pb-6 w-full max-w-3xl mx-auto">
+          <p className="text-sm text-ink-muted">Patient not found.</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-bg flex flex-col">

--- a/web-app/src/pages/PatientChart.tsx
+++ b/web-app/src/pages/PatientChart.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft, Download, Printer, ChevronDown, ChevronRight } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
@@ -6,15 +6,57 @@ import { RiskBadge, riskColor } from '../components/RiskBadge'
 import { XrayThumbnail } from '../components/XrayThumbnail'
 import { XrayLightbox } from '../components/XrayLightbox'
 import { getPatient } from '../lib/storage'
+import type { Patient } from '../lib/storage'
 
 export function PatientChart() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
-  const patient = id ? getPatient(id) : null
+  const [patient, setPatient] = useState<Patient | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
   // Hooks must come before any early return (Rules of Hooks)
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
   // null = default (last bucket open); Set = user's explicit choices
   const [openBuckets, setOpenBuckets] = useState<Set<string> | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!id) {
+      setLoading(false)
+      setPatient(null)
+      return
+    }
+    setLoading(true)
+    ;(async () => {
+      try {
+        const p = await getPatient(id)
+        if (!cancelled) setPatient(p)
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">Loading patient…</p>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">{loadError}</p>
+      </div>
+    )
+  }
 
   if (!patient) {
     return (

--- a/web-app/src/pages/PatientIntakeStep2.tsx
+++ b/web-app/src/pages/PatientIntakeStep2.tsx
@@ -71,7 +71,7 @@ export function PatientIntakeStep2() {
     try {
       const result = await predictWithContributions(features)
       const id = generateId()
-      savePatient({
+      await savePatient({
         id,
         name: draft.name ?? 'Unknown',
         medicalId: draft.medicalId ?? id,

--- a/web-app/src/pages/PatientIntakeStep2.tsx
+++ b/web-app/src/pages/PatientIntakeStep2.tsx
@@ -4,7 +4,7 @@ import { Info } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
 import { StepProgress } from '../components/StepProgress'
 import { getChoices, predictWithContributions } from '../lib/inference'
-import { savePatient, generateId } from '../lib/storage'
+import { savePatient, generateId, addPrediction } from '../lib/storage'
 import type { PatientFeatures } from '../lib/inference'
 import { PageFooter } from '../components/PageFooter'
 
@@ -78,14 +78,15 @@ export function PatientIntakeStep2() {
         features,
         treatmentStartDate: dateStartedTx,
         createdAt: Date.now(),
-        predictions: [{
-          label: result.label,
-          failureProbability: result.failureProbability,
-          contributions: result.contributions,
-          featuresUsed: features,
-          timestamp: Date.now(),
-        }],
+        predictions: [],
         monthlyRecords: [],
+      })
+      await addPrediction(id, {
+        label: result.label,
+        failureProbability: result.failureProbability,
+        contributions: result.contributions,
+        featuresUsed: features,
+        timestamp: Date.now(),
       })
       sessionStorage.removeItem(DRAFT_KEY)
       navigate('/patient/new/xray', { state: { id, result } })

--- a/web-app/src/pages/PatientIntakeXray.tsx
+++ b/web-app/src/pages/PatientIntakeXray.tsx
@@ -71,9 +71,7 @@ export function PatientIntakeXray() {
           <div className="bg-blue-50 border border-blue-100 rounded-2xl p-3 flex gap-2.5 items-start">
             <Info size={16} className="text-blue-500 mt-0.5 flex-shrink-0" aria-hidden="true" />
             <p className="text-xs text-blue-700">
-              Images are stored locally in this browser for now.{' '}
-              {/* TODO(server): remove local-storage note once server upload is implemented */}
-              In a production deployment, images should be uploaded to a secure server endpoint.
+              Images are uploaded to the local backend on this workstation.
             </p>
           </div>
 

--- a/web-app/src/pages/PatientProfile.tsx
+++ b/web-app/src/pages/PatientProfile.tsx
@@ -1,13 +1,56 @@
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { AppHeader } from '../components/AppHeader'
 import { RiskBadge, riskColor } from '../components/RiskBadge'
 import { getPatient } from '../lib/storage'
 import { PageFooter } from '../components/PageFooter'
+import type { Patient } from '../lib/storage'
 
 export function PatientProfile() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
-  const patient = id ? getPatient(id) : null
+  const [patient, setPatient] = useState<Patient | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    if (!id) {
+      setLoading(false)
+      setPatient(null)
+      return
+    }
+    setLoading(true)
+    ;(async () => {
+      try {
+        const p = await getPatient(id)
+        if (!cancelled) setPatient(p)
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">Loading patient…</p>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">{loadError}</p>
+      </div>
+    )
+  }
 
   if (!patient) {
     return (

--- a/web-app/src/pages/RiskUpdate.tsx
+++ b/web-app/src/pages/RiskUpdate.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { ArrowUp, ArrowDown, Info } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
@@ -5,14 +6,56 @@ import { RiskBadge, riskColor } from '../components/RiskBadge'
 import { getPatient } from '../lib/storage'
 import type { ContributionResult } from '../lib/inference'
 import { PageFooter } from '../components/PageFooter'
+import type { Patient } from '../lib/storage'
 
 export function RiskUpdate() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
   const location = useLocation()
-  const patient = id ? getPatient(id) : null
+  const [patient, setPatient] = useState<Patient | null>(null)
+  const [loadingPatient, setLoadingPatient] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const result: ContributionResult | null = location.state?.result ?? null
   const monthNumber: number = location.state?.monthNumber ?? 1
+
+  useEffect(() => {
+    let cancelled = false
+    if (!id) {
+      setLoadingPatient(false)
+      setPatient(null)
+      return
+    }
+    setLoadingPatient(true)
+    ;(async () => {
+      try {
+        const p = await getPatient(id)
+        if (!cancelled) setPatient(p)
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoadingPatient(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  if (loadingPatient) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">Loading patient…</p>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">{loadError}</p>
+      </div>
+    )
+  }
 
   const prob     = result?.failureProbability ?? 0
   const prevProb = patient?.predictions.at(-2)?.failureProbability

--- a/web-app/src/pages/RiskUpdate.tsx
+++ b/web-app/src/pages/RiskUpdate.tsx
@@ -57,13 +57,17 @@ export function RiskUpdate() {
     )
   }
 
-  const prob     = result?.failureProbability ?? 0
-  const prevProb = patient?.predictions.at(-2)?.failureProbability
-  const delta    = prevProb != null ? prob - prevProb : null
+  const latestPrediction = patient?.predictions.at(-1)
+  const prob = result?.failureProbability ?? latestPrediction?.failureProbability ?? 0
+  const prevProb = patient && patient.predictions.length > 1
+    ? patient.predictions.at(-2)?.failureProbability
+    : undefined
+  const delta = prevProb != null ? prob - prevProb : null
   const isHigh   = prob >= 0.5
   const { text } = riskColor(prob)
 
-  const topContribs = result?.contributions.slice(0, 3) ?? []
+  const topContribs = (result?.contributions ?? latestPrediction?.contributions ?? []).slice(0, 3)
+  const derivedMonthNumber = monthNumber || patient?.monthlyRecords.at(-1)?.month || 1
 
   const riskGradient = isHigh
     ? 'bg-gradient-to-br from-risk-high/5 to-risk-high/15 border-risk-high/40'
@@ -77,8 +81,8 @@ export function RiskUpdate() {
         <div className="flex justify-between items-start">
           <div>
             <p className="font-bold text-ink-base font-display">{patient?.name}</p>
-            <p className="text-xs text-ink-secondary">{patient?.medicalId} · Month {monthNumber}</p>
-            <p className="text-xs text-ink-muted">{patient?.treatmentRegimen?.toUpperCase() || ''} · {monthNumber} of 6 months</p>
+            <p className="text-xs text-ink-secondary">{patient?.medicalId} · Month {derivedMonthNumber}</p>
+            <p className="text-xs text-ink-muted">{patient?.treatmentRegimen?.toUpperCase() || ''} · {derivedMonthNumber} of 6 months</p>
           </div>
           <RiskBadge probability={prob} size="md" />
         </div>

--- a/web-app/src/pages/TreatmentSelection.tsx
+++ b/web-app/src/pages/TreatmentSelection.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { CheckCircle2 } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
 import { StepProgress } from '../components/StepProgress'
 import { getPatient, savePatient } from '../lib/storage'
 import { PageFooter } from '../components/PageFooter'
+import type { Patient } from '../lib/storage'
 
 type RegimenId = 'hrze' | 'mdr' | 'xdr'
 
@@ -35,20 +36,64 @@ const REGIMENS: Array<{ id: RegimenId; name: string; drugs: string; duration: st
 export function TreatmentSelection() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
-  const patient = id ? getPatient(id) : null
+  const [patient, setPatient] = useState<Patient | null>(null)
+  const [loadingPatient, setLoadingPatient] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
 
-  const [selected, setSelected] = useState<RegimenId | ''>(patient?.treatmentRegimen ?? '')
-  const [startDate, setStartDate] = useState(patient?.treatmentStartDate ?? '')
+  const [selected, setSelected] = useState<RegimenId | ''>('')
+  const [startDate, setStartDate] = useState('')
 
-  function handleProceed() {
+  useEffect(() => {
+    let cancelled = false
+    if (!id) {
+      setLoadingPatient(false)
+      setPatient(null)
+      return
+    }
+    setLoadingPatient(true)
+    ;(async () => {
+      try {
+        const p = await getPatient(id)
+        if (cancelled) return
+        setPatient(p)
+        setSelected(((p?.treatmentRegimen as RegimenId | undefined) ?? ''))
+        setStartDate(p?.treatmentStartDate ?? '')
+      } catch (e) {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoadingPatient(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  async function handleProceed() {
     if (!id || !selected) return
-    const p = getPatient(id)
+    const p = patient ?? (await getPatient(id))
     if (p) {
       p.treatmentRegimen = selected || undefined
       p.treatmentStartDate = startDate
-      savePatient(p)
+      await savePatient(p)
     }
     navigate(`/patient/${id}`)
+  }
+
+  if (loadingPatient) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">Loading patient…</p>
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <p className="text-ink-muted">{loadError}</p>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary

Closes #54
Closes #55

This PR completes the backend persistence migration work and demo seeding tooling, then follows through with QA-driven fixes for risk persistence and seeded feature-contribution consistency.

### What’s included

- Backend persistence stack (SQLite + SQLAlchemy + Alembic) and API endpoints for patients, predictions, monthly records, and X-rays.
- Frontend migration to async backend-backed storage calls across affected pages.
- Demo data CLI (`python -m backend.seed_demo`) with guarded reset options.
- Risk persistence fixes (initial intake prediction persistence + risk update hydration on reload/direct navigation).
- Seeder quality hardening so seeded records match UI-selectable values and full feature-contribution expectations.
- New backend tests for migration/API behavior and seed/reset data integrity.

---

## Linked Issues

- Closes #54
- Closes #55

---

## Why this change

### #54 (Persistence migration + UI integration)
The app needed to stop relying on local-only persistence assumptions and move patient/risk/X-ray state to backend APIs, while keeping frontend behavior stable.

### #55 (Seeder/reset + demo-data fidelity)
We needed reliable demo data tooling, plus seeded records that look and behave like real app-generated records in feature analysis and risk views.

---

## Detailed Changes

### Backend: persistence, schema, and APIs

- Added backend package files and DB infrastructure:
  - `backend/db.py`
  - `backend/models.py`
  - `backend/schemas.py`
  - `backend/settings.py`
- Added Alembic migration setup:
  - `backend/alembic.ini`
  - `backend/alembic/*`
- Extended API in `backend/main.py`:
  - `GET /api/patients`
  - `POST /api/patients`
  - `PUT /api/patients/{patient_id}`
  - `GET /api/patients/{patient_id}`
  - `POST /api/patients/{patient_id}/monthly-records`
  - `POST /api/patients/{patient_id}/predictions`
  - `POST /api/xrays`
  - `GET /api/xrays/{xray_id}/file`
  - `GET /api/patients/{patient_id}/xrays`
- Added filesystem-backed X-ray storage:
  - `backend/xray_store.py`
- Added backend dependencies in `backend/requirements.txt`.

### Frontend: async API migration and persistence safety

Updated storage + page flows to use backend APIs and async loading:

- `web-app/src/lib/storage.ts`
- `web-app/src/lib/useXrayUrl.ts`
- `web-app/src/pages/Home.tsx`
- `web-app/src/pages/Dashboard.tsx`
- `web-app/src/pages/DiagnosticResult.tsx`
- `web-app/src/pages/FeatureContribution.tsx`
- `web-app/src/pages/MonthlyCheckin.tsx`
- `web-app/src/pages/PatientChart.tsx`
- `web-app/src/pages/PatientProfile.tsx`
- `web-app/src/pages/RiskUpdate.tsx`
- `web-app/src/pages/TreatmentSelection.tsx`
- `web-app/src/pages/PatientIntakeStep2.tsx`
- `web-app/src/pages/PatientIntakeXray.tsx`

### Risk bug fixes (QA findings)

- Fixed intake flow persistence path:
  - `PatientIntakeStep2` now saves patient then persists initial prediction via prediction endpoint.
- Fixed risk update hydration:
  - `RiskUpdate` now falls back to DB-backed latest prediction/contributions on reload/direct access when route state is absent.

### Seeder CLI and demo-data quality

Added and hardened:

- `backend/seed_demo.py`
- `backend/README.md`
- `backend/tests/test_seed_demo.py`

Seeder supports:

- `python -m backend.seed_demo`
- `--include-xrays`
- `--reset`, `--reset-db`, `--reset-xrays` (guarded by `TB_ALLOW_DEV_RESET=1`)

Hardening added:

- Required form/feature field validation.
- Per-prediction `features_used` completeness/type validation.
- Full feature-contribution seeding to match feature-analysis UX contract.
- Validation that seeded categorical values are selectable from UI encodings (`web-app/src/data/feature_encodings.json`).

### Dev workflow

- Updated `dev.sh` to launch backend via package entrypoint (`backend.main:app`) from repo root and align dependency checks.

---

## Verification

### Automated

- Backend tests: `python3 -m pytest -q` (passing)
- Frontend build: `npm run build` (passing)

### Manual E2E QA (Playwright CLI)

Validated core end-to-end persistence and display flows:

- Intake generates and persists initial prediction.
- Risk update view correctly hydrates from DB on direct load/reload.
- Cross-page consistency (Home/Dashboard/Profile/Features).
- Seeded Demo Patient B feature contributions now render complete feature set.

---

## Operational Notes

Seed DB (empty DB only):

```bash
python -m backend.seed_demo
```

Reset and reseed:

```bash
TB_ALLOW_DEV_RESET=1 python -m backend.seed_demo --reset --include-xrays
```

Reset DB only:

```bash
TB_ALLOW_DEV_RESET=1 python -m backend.seed_demo --reset-db
```

---

## Risk / Impact

- Primary impact is on persistence and data lifecycle behavior.
- Changes are additive and aligned with the migration direction.
- Destructive reset operations require explicit opt-in guard (`TB_ALLOW_DEV_RESET=1`).