### PR TITLE
fix: persist intake draft and commit patient at step 3

### DIFF
--- a/web-app/src/lib/intakeDraft.ts
+++ b/web-app/src/lib/intakeDraft.ts
@@ -1,0 +1,82 @@
+import type { ContributionResult, PatientFeatures } from './inference'
+import { addPrediction, savePatient } from './storage'
+import type { Patient } from './storage'
+
+export const INTAKE_DRAFT_KEY = 'tb_intake_draft'
+
+export interface IntakeDraft {
+  draftPatientId?: string
+  name?: string
+  age?: number
+  sex?: string
+  medicalId?: string
+  province?: string
+  city?: string
+  registrationGroup?: string
+  bacteriologicStatus?: string
+  microscopyResult?: string
+  anatomicalSite?: string
+  sourceOfPatient?: string
+  type?: string
+  treatmentFacility?: string
+  screeningFacility?: string
+  dateStartedTx?: string
+  dateOfDiagnosis?: string
+  features?: PatientFeatures
+  result?: ContributionResult
+}
+
+export type CommitReadyIntakeDraft = IntakeDraft & {
+  draftPatientId: string
+  features: PatientFeatures
+  result: ContributionResult
+}
+
+export function createDraftPatientId(): string {
+  return `MED-${new Date().getFullYear()}-${Math.floor(Math.random() * 9000 + 1000)}`
+}
+
+export function loadIntakeDraft(): IntakeDraft {
+  try {
+    return JSON.parse(sessionStorage.getItem(INTAKE_DRAFT_KEY) || '{}') as IntakeDraft
+  } catch {
+    return {}
+  }
+}
+
+export function saveIntakeDraft(draft: IntakeDraft): void {
+  sessionStorage.setItem(INTAKE_DRAFT_KEY, JSON.stringify(draft))
+}
+
+export function clearIntakeDraft(): void {
+  sessionStorage.removeItem(INTAKE_DRAFT_KEY)
+}
+
+export function hasCommitReadyDraft(draft: IntakeDraft): draft is CommitReadyIntakeDraft {
+  return Boolean(draft.draftPatientId && draft.features && draft.result)
+}
+
+export async function commitIntakePatient(draft: CommitReadyIntakeDraft): Promise<{ id: string; result: ContributionResult }> {
+  const patient: Patient = {
+    id: draft.draftPatientId,
+    name: draft.name ?? 'Unknown',
+    medicalId: draft.medicalId ?? draft.draftPatientId,
+    features: draft.features,
+    treatmentStartDate: draft.dateStartedTx,
+    createdAt: Date.now(),
+    predictions: [],
+    monthlyRecords: [],
+  }
+
+  await savePatient(patient)
+  await addPrediction(draft.draftPatientId, {
+    label: draft.result.label,
+    failureProbability: draft.result.failureProbability,
+    contributions: draft.result.contributions,
+    featuresUsed: draft.features,
+    timestamp: Date.now(),
+  })
+
+  clearIntakeDraft()
+  return { id: draft.draftPatientId, result: draft.result }
+}

--- a/web-app/src/pages/PatientIntakeStep1.tsx
+++ b/web-app/src/pages/PatientIntakeStep1.tsx
@@ -4,12 +4,7 @@ import { AppHeader } from '../components/AppHeader'
 import { StepProgress } from '../components/StepProgress'
 import { getChoices, getCitiesForProvince } from '../lib/inference'
 import { PageFooter } from '../components/PageFooter'
-
-const DRAFT_KEY = 'tb_intake_draft'
-
-function loadDraft() {
-  try { return JSON.parse(sessionStorage.getItem(DRAFT_KEY) || '{}') } catch { return {} }
-}
+import { createDraftPatientId, loadIntakeDraft, saveIntakeDraft } from '../lib/intakeDraft'
 
 const inputCls = 'w-full min-h-[44px] border border-border rounded-xl px-3 py-2.5 text-sm text-ink-base bg-surface placeholder-ink-muted focus:border-primary outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1'
 const selectCls = `${inputCls} bg-surface`
@@ -17,12 +12,13 @@ const labelCls = 'block text-sm font-medium text-ink-secondary mb-1'
 
 export function PatientIntakeStep1() {
   const navigate = useNavigate()
-  const draft = loadDraft()
+  const draft = loadIntakeDraft()
+  const initialMedicalId = draft.medicalId ?? draft.draftPatientId ?? createDraftPatientId()
 
   const [name, setName] = useState(draft.name ?? '')
-  const [age, setAge] = useState<string>(draft.age ?? '')
+  const [age, setAge] = useState<string>(draft.age ? String(draft.age) : '')
   const [sex, setSex] = useState(draft.sex ?? '')
-  const [medicalId, setMedicalId] = useState(draft.medicalId ?? `MED-${new Date().getFullYear()}-${Math.floor(Math.random() * 9000 + 1000)}`)
+  const [medicalId, setMedicalId] = useState(initialMedicalId)
   const [province, setProvince] = useState(draft.province ?? '')
   const [city, setCity] = useState(draft.city ?? '')
   const [registrationGroup, setRegistrationGroup] = useState(draft.registrationGroup ?? '')
@@ -35,8 +31,18 @@ export function PatientIntakeStep1() {
   const valid = name && age && sex && province && registrationGroup
 
   function handleContinue() {
-    const updated = { ...draft, name, age: Number(age), sex, medicalId, province, city, registrationGroup }
-    sessionStorage.setItem(DRAFT_KEY, JSON.stringify(updated))
+    const updated = {
+      ...draft,
+      draftPatientId: draft.draftPatientId ?? medicalId,
+      name,
+      age: Number(age),
+      sex,
+      medicalId,
+      province,
+      city,
+      registrationGroup,
+    }
+    saveIntakeDraft(updated)
     navigate('/patient/new/lab')
   }
 

--- a/web-app/src/pages/PatientIntakeStep2.tsx
+++ b/web-app/src/pages/PatientIntakeStep2.tsx
@@ -4,15 +4,9 @@ import { Info } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
 import { StepProgress } from '../components/StepProgress'
 import { getChoices, predictWithContributions } from '../lib/inference'
-import { savePatient, generateId, addPrediction } from '../lib/storage'
 import type { PatientFeatures } from '../lib/inference'
 import { PageFooter } from '../components/PageFooter'
-
-const DRAFT_KEY = 'tb_intake_draft'
-
-function loadDraft() {
-  try { return JSON.parse(sessionStorage.getItem(DRAFT_KEY) || '{}') } catch { return {} }
-}
+import { createDraftPatientId, loadIntakeDraft, saveIntakeDraft } from '../lib/intakeDraft'
 
 const inputCls = 'w-full min-h-[44px] border border-border rounded-xl px-3 py-2.5 text-sm text-ink-base bg-surface placeholder-ink-muted focus:border-primary outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1'
 const selectCls = `${inputCls} bg-surface`
@@ -20,7 +14,7 @@ const labelCls = 'block text-sm font-medium text-ink-secondary mb-1'
 
 export function PatientIntakeStep2() {
   const navigate = useNavigate()
-  const draft = loadDraft()
+  const draft = loadIntakeDraft()
 
   const [bacteriologicStatus, setBacteriologicStatus] = useState(draft.bacteriologicStatus ?? '')
   const [microscopyResult, setMicroscopyResult] = useState(draft.microscopyResult ?? '')
@@ -70,26 +64,23 @@ export function PatientIntakeStep2() {
 
     try {
       const result = await predictWithContributions(features)
-      const id = generateId()
-      await savePatient({
-        id,
-        name: draft.name ?? 'Unknown',
-        medicalId: draft.medicalId ?? id,
+      const draftPatientId = draft.draftPatientId ?? draft.medicalId ?? createDraftPatientId()
+      saveIntakeDraft({
+        ...draft,
+        draftPatientId,
+        bacteriologicStatus,
+        microscopyResult,
+        anatomicalSite,
+        sourceOfPatient,
+        type,
+        treatmentFacility,
+        screeningFacility,
+        dateStartedTx,
+        dateOfDiagnosis,
         features,
-        treatmentStartDate: dateStartedTx,
-        createdAt: Date.now(),
-        predictions: [],
-        monthlyRecords: [],
+        result,
       })
-      await addPrediction(id, {
-        label: result.label,
-        failureProbability: result.failureProbability,
-        contributions: result.contributions,
-        featuresUsed: features,
-        timestamp: dateOfDiagnosis ? new Date(dateOfDiagnosis).getTime() : 0,
-      })
-      sessionStorage.removeItem(DRAFT_KEY)
-      navigate('/patient/new/xray', { state: { id, result } })
+      navigate('/patient/new/xray')
     } catch (err) {
       console.error(err)
       alert('Inference failed. Check the browser console for details.')
@@ -202,7 +193,7 @@ export function PatientIntakeStep2() {
 
       <PageFooter>
         <div className="flex gap-3">
-          <button onClick={() => navigate(-1)}
+          <button onClick={() => navigate('/patient/new')}
             className="flex-1 border border-border text-ink-secondary py-3.5 rounded-xl font-semibold text-sm active:bg-gray-50">
             ← Back
           </button>

--- a/web-app/src/pages/PatientIntakeXray.tsx
+++ b/web-app/src/pages/PatientIntakeXray.tsx
@@ -1,43 +1,40 @@
 import { useState } from 'react'
-import { useNavigate, useLocation, Navigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router-dom'
 import { Info } from 'lucide-react'
 import { AppHeader } from '../components/AppHeader'
 import { StepProgress } from '../components/StepProgress'
 import { PageFooter } from '../components/PageFooter'
 import { XrayUploadField } from '../components/XrayUploadField'
 import { attachIntakeXrays } from '../lib/storage'
-import type { ContributionResult } from '../lib/inference'
+import { commitIntakePatient, hasCommitReadyDraft, loadIntakeDraft } from '../lib/intakeDraft'
+import type { CommitReadyIntakeDraft } from '../lib/intakeDraft'
 
 export function PatientIntakeXray() {
   const navigate = useNavigate()
-  const location = useLocation()
-  const state = location.state as { id?: string; result?: ContributionResult } | null
+  const draft = loadIntakeDraft()
 
   const [files, setFiles] = useState<File[]>([])
   const [saving, setSaving] = useState(false)
 
-  // Guard: if landed without state (e.g. page refresh), redirect back to wizard start.
-  // Use <Navigate> rather than navigate() to avoid a side-effect during render.
-  if (!state?.id || !state?.result) {
-    return <Navigate to="/patient/new" replace />
+  if (!hasCommitReadyDraft(draft)) {
+    return <Navigate to={draft.name ? '/patient/new/lab' : '/patient/new'} replace />
   }
+  const commitDraft: CommitReadyIntakeDraft = draft
 
-  const { id, result } = state
-
-  function goToResult() {
-    navigate(`/patient/${id}/result`, { state: { result, fresh: true } })
-  }
-
-  async function handleContinue() {
+  async function commitAndOpenResult(uploadFiles: File[]) {
     setSaving(true)
     try {
-      await attachIntakeXrays(id, files)
-      goToResult()
+      const committed = await commitIntakePatient(commitDraft)
+      try {
+        await attachIntakeXrays(committed.id, uploadFiles)
+      } catch (err) {
+        console.error('Failed to attach X-rays:', err)
+        alert('The patient was saved, but X-ray upload failed. You can add images from the patient chart later.')
+      }
+      navigate(`/patient/${committed.id}/result`, { state: { result: committed.result, fresh: true } })
     } catch (err) {
-      console.error('Failed to attach X-rays:', err)
-      // Note: the patient record is already saved without X-rays (Step 2 committed it).
-      // Going back from this page produces a valid patient record, just without imaging.
-      alert('Could not save X-ray images. You can skip and add images from the patient chart later.')
+      console.error('Failed to save patient intake:', err)
+      alert('Could not save the patient. Please try again before leaving this step.')
     } finally {
       setSaving(false)
     }
@@ -83,20 +80,21 @@ export function PatientIntakeXray() {
         <div className="space-y-2">
           <div className="flex gap-3">
             <button
-              onClick={() => navigate(-1)}
+              onClick={() => navigate('/patient/new/lab')}
               className="flex-1 border border-border text-ink-secondary py-3 rounded-xl font-semibold text-sm active:bg-gray-50"
             >
               ← Back
             </button>
             <button
-              onClick={goToResult}
-              className="flex-1 border border-border text-ink-secondary py-3 rounded-xl font-semibold text-sm active:bg-gray-50"
+              onClick={() => commitAndOpenResult([])}
+              disabled={saving}
+              className="flex-1 border border-border text-ink-secondary py-3 rounded-xl font-semibold text-sm active:bg-gray-50 disabled:opacity-40"
             >
               Skip
             </button>
           </div>
           <button
-            onClick={handleContinue}
+            onClick={() => commitAndOpenResult(files)}
             disabled={files.length === 0 || saving}
             className="w-full bg-primary text-white py-3.5 rounded-xl font-semibold text-sm disabled:opacity-40 active:bg-primary-dark"
           >


### PR DESCRIPTION
## Summary
- persist Add Patient wizard data in `sessionStorage` across Steps 1-3 so Back navigation keeps entered values instead of restarting the flow
- move patient/prediction persistence to a single commit boundary in Step 3 (Skip or Upload & Continue), and route back navigation explicitly between wizard steps
- add a startup migration step in `dev.sh` so local API bootstraps schema before serving requests, avoiding missing-table 500s during intake

## Validation
- `npm run build` (web-app)
- `pytest backend/tests/test_migrations_and_api.py backend/tests/test_seed_demo.py -q`
- manual Playwright flow: Step 1 -> Step 2 -> Step 3 (Skip) -> Step 4 result, then Patient Overview shows committed patient