### PR TITLE
fix: update navigation behavior in MonthlyCheckin and RiskUpdate components

### DIFF
--- a/web-app/src/pages/MonthlyCheckin.tsx
+++ b/web-app/src/pages/MonthlyCheckin.tsx
@@ -82,7 +82,7 @@ export function MonthlyCheckin() {
         timestamp: now,
       })
 
-      navigate(`/patient/${id}/risk-update`, { state: { result, monthNumber } })
+      navigate(`/patient/${id}/risk-update`, { state: { result, monthNumber }, replace: true })
     } catch (err) {
       console.error(err)
       alert('Inference failed.')

--- a/web-app/src/pages/RiskUpdate.tsx
+++ b/web-app/src/pages/RiskUpdate.tsx
@@ -129,7 +129,7 @@ export function RiskUpdate() {
 
       <PageFooter>
         <div className="flex gap-3">
-          <button onClick={() => navigate(-1)}
+          <button onClick={() => navigate(`/patient/${id}/chart`)}
             className="flex-1 border border-border text-ink-secondary py-3.5 rounded-xl font-semibold text-sm">
             ← Back
           </button>


### PR DESCRIPTION
## What does this PR do?
This pull request makes minor improvements to the navigation flow in the patient check-in and risk update pages. The changes ensure a smoother user experience by updating navigation behavior after submitting a check-in and when returning from the risk update page.

Navigation improvements:

* After submitting a monthly check-in, navigating to the risk update page now uses the `replace` option to prevent the user from returning to the check-in page with the browser back button (`MonthlyCheckin.tsx`).
* The "Back" button on the risk update page now takes the user directly to the patient's chart page, rather than simply navigating back in history (`RiskUpdate.tsx`).

## Related Issue
Closes #76 

## Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Improvement
- [ ] Technical / Infrastructure

## How was this tested?
- [x] Local dev
- [x] Manual testing
- [ ] Automated tests (if applicable)

## Screenshots / Notes
(optional)
