### PR TITLE
feat: add --lan flag to dev.sh for LAN exposure

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # dev.sh — start backend API + React frontend with a live dashboard
-# Usage: ./dev.sh [--from-source]
+# Usage: ./dev.sh [--from-source] [--lan]
 #   --from-source  compile llama-cpp-python from C++ source instead of using the
 #                  prebuilt Metal/CUDA wheel (slower; only needed for unsupported
 #                  Python versions or custom CUDA architectures)
+#   --lan          bind both services to 0.0.0.0 so other devices on the LAN
+#                  can reach the backend and frontend
 
 set -Eeuo pipefail
 
@@ -24,7 +26,14 @@ readonly LLAMA_VER_CU124="0.3.22"   # CUDA 12.4 — driver >= 550
 readonly LLAMA_VER_CU121="0.3.23"   # CUDA 12.1 — driver >= 530 (fallback)
 
 FROM_SOURCE=false
-[[ "${1:-}" == "--from-source" ]] && FROM_SOURCE=true
+LAN_MODE=false
+for _arg in "$@"; do
+  case "$_arg" in
+    --from-source) FROM_SOURCE=true ;;
+    --lan)         LAN_MODE=true ;;
+    *) err "Unknown argument: $_arg"; exit 1 ;;
+  esac
+done
 
 # ── colors / ANSI ─────────────────────────────────────────────────────────────
 is_tty() { [[ -t 1 ]]; }
@@ -317,13 +326,18 @@ else
 fi
 
 # ── start services ────────────────────────────────────────────────────────────
-log "Starting backend API on :$BACKEND_PORT  (log → logs/backend-${_TS}.log)"
-"$UVICORN" backend.main:app --port "$BACKEND_PORT" --log-level info \
+BIND_HOST="127.0.0.1"
+[[ "$LAN_MODE" == "true" ]] && BIND_HOST="0.0.0.0"
+
+log "Starting backend API on ${BIND_HOST}:$BACKEND_PORT  (log → logs/backend-${_TS}.log)"
+"$UVICORN" backend.main:app --host "$BIND_HOST" --port "$BACKEND_PORT" --log-level info \
   >> "$BACKEND_LOG" 2>&1 &
 BACKEND_PID=$!
 
-log "Starting React frontend on :$FRONTEND_PORT  (log → logs/frontend-${_TS}.log)"
-(cd "$WEBAPP" && npm run dev -- --port "$FRONTEND_PORT") \
+log "Starting React frontend on ${BIND_HOST}:$FRONTEND_PORT  (log → logs/frontend-${_TS}.log)"
+_FE_HOST_FLAG=""
+[[ "$LAN_MODE" == "true" ]] && _FE_HOST_FLAG="--host"
+(cd "$WEBAPP" && npm run dev -- --port "$FRONTEND_PORT" $_FE_HOST_FLAG) \
   >> "$FRONTEND_LOG" 2>&1 &
 FRONTEND_PID=$!
 
@@ -480,6 +494,12 @@ draw_dashboard() {
   echo ""
   echo -e "  ${DIM}$DIVIDER${RESET}"
   echo -e "  ${DIM}Backend → http://localhost:${actual_be_port}   Frontend → http://localhost:${actual_fe_port}${RESET}"
+  if [[ "$LAN_MODE" == "true" ]]; then
+    local _lan_ip
+    _lan_ip=$(ip route get 1.1.1.1 2>/dev/null | awk '/src/{for(i=1;i<=NF;i++) if($i=="src") print $(i+1)}' \
+      || hostname -I 2>/dev/null | awk '{print $1}' || echo "?")
+    echo -e "  ${YELLOW}LAN → http://${_lan_ip}:${actual_be_port}   http://${_lan_ip}:${actual_fe_port}${RESET}"
+  fi
   echo -e "  ${DIM}logs/backend-${_TS}.log  |  logs/frontend-${_TS}.log  |  Ctrl+C to stop${RESET}"
 }
 


### PR DESCRIPTION
## Summary

- Adds a `--lan` flag to `dev.sh` that binds both the backend (uvicorn) and frontend (Vite) to `0.0.0.0` instead of `127.0.0.1`
- Dashboard footer displays a resolved LAN IP line when the flag is active
- Replaces the single-arg parse with a `for` loop so multiple flags can be combined freely
- Unknown arguments now exit with a clear error instead of being silently ignored

## Usage

**Normal (localhost only — default, unchanged):**
```bash
./dev.sh
```

**LAN mode — expose to other devices on your network:**
```bash
./dev.sh --lan
```

**Combined with source build:**
```bash
./dev.sh --lan --from-source
```

When `--lan` is active the dashboard footer shows an extra yellow line:
```
LAN → http://192.168.1.42:8000   http://192.168.1.42:5173
```
Share those URLs with any device on the same Wi-Fi/subnet.

## Notes

- `--lan` does **not** add authentication or firewall rules — only use it on trusted networks
- LAN IP is resolved via `ip route get 1.1.1.1` (Linux) with `hostname -I` as a fallback

## Test plan

- [x] `./dev.sh` starts as before, services bind to `127.0.0.1` only
- [x] `./dev.sh --lan` starts both services bound to `0.0.0.0`; dashboard shows LAN IP line
- [x] Another device on the same LAN can open the frontend and hit the API
- [x] `./dev.sh --lan --from-source` works (flags are order-independent)
- [x] `./dev.sh --invalid` exits with `Unknown argument: --invalid`